### PR TITLE
127 connecting kakao api

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=36046467d9db2502cafd92b5ee6a7a7a"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%"
     ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%&libraries=clusterer"
     ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=36046467d9db2502cafd92b5ee6a7a7a"
     ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+const { kakao } = window;
+
+export default function CustomMap() {
+  const container = useRef(null);
+  // const staticContainer = useRef(null);
+  const options = {
+    center: new kakao.maps.LatLng(37.56637787425258, 126.97827585270615), // 지도 중심지지
+    level: 5, // 확대 정도
+  };
+
+  useEffect(() => {
+    console.log(container);
+
+    const map = new kakao.maps.Map(container.current, options);
+
+    const markerPosition = new kakao.maps.LatLng(37.56637787425258, 126.97827585270615); // 지도 마커 위치
+    new kakao.maps.Marker({ map, position: markerPosition }); // 지도 마커 표시
+
+    // const staticOptions = {
+    //   center: new kakao.maps.LatLng(33.450701, 126.570667), // 이미지 지도의 중심좌표
+    //   level: 3, // 이미지 지도의 확대 레벨
+    // };
+
+    // const staticMap = new kakao.maps.staticMap(staticContainer, staticOptions);
+    // console.log(staticMap);
+    // new kakao.maps.Marker({ staticMap, position: markerPosition });
+
+    // 마커 클릭 시 카카오 지도 오픈
+    // kakao.maps.event.addListener(marker, "click", function () {
+    //   handleOpenNewTab(
+    //     "https://map.kakao.com/link/map/37.56637787425258,126.97827585270615"
+    //   );
+    // });
+
+    // 커스텀 오버레이 - https://apis.map.kakao.com/web/sample/roadviewCustomOverlay/
+  }, []);
+  return <div id="staticMap" ref={container} style={{ width: "100%", height: "100%" }}></div>;
+}

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -49,14 +49,14 @@ export default function CustomMap({ markers, type }: MapProps) {
 
         const content = document.createElement("div");
         content.innerHTML =
-          '<div class="rounded absolute left-0 bottom-14 drop-shadow -translate-x-1/2">' +
+          '<div class="rounded absolute left-0 bottom-14 drop-shadow -translate-x-1/2 w-fit">' +
           '    <div class="after:absolute after:left-1/2 after:-translate-x-1/2 after:border-[10px] after:border-b-0 after:border-x-transparent after:border-white">' +
-          '        <div class="flex justify-between items-center bg-gray-scale-100 py-1 px-2 text-sub-title">' +
+          '        <div class="flex gap-5 justify-between items-center bg-gray-scale-100 py-1 px-2 text-sub-title">' +
           data.facltNm +
-          '<img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/overlay_close.png" id="close" class="w-4 h-4 hover:cursor-pointer" />' +
+          '<div class="w-4 h-4 hover:cursor-pointer p-0.5" id="close"><img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/overlay_close.png" /></div>' +
           "        </div>" +
           '        <div class="p-2 overflow-hidden bg-white flex flex-col gap-1">' +
-          '            <div class="img w-full">' +
+          '            <div class="w-full">' +
           `<img src="${data.firstImageUrl}">` +
           "           </div>" +
           '            <div class="desc flex flex-col text-[15px]">' +

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -1,40 +1,28 @@
+import { MapProps } from "types/common";
 import { useEffect, useRef } from "react";
 
 const { kakao } = window;
 
-export default function CustomMap() {
+export default function CustomMap({ markers }: MapProps) {
   const container = useRef(null);
-  // const staticContainer = useRef(null);
-  const options = {
-    center: new kakao.maps.LatLng(37.56637787425258, 126.97827585270615), // 지도 중심지지
-    level: 5, // 확대 정도
-  };
 
   useEffect(() => {
-    console.log(container);
+    const { mapX: centerX, mapY: centerY } = markers[0];
 
+    const options = {
+      center: new kakao.maps.LatLng(
+        Number(centerY) || 37.56637787425258,
+        Number(centerX) || 126.97827585270615,
+      ),
+      level: 5,
+    };
     const map = new kakao.maps.Map(container.current, options);
 
-    const markerPosition = new kakao.maps.LatLng(37.56637787425258, 126.97827585270615); // 지도 마커 위치
-    new kakao.maps.Marker({ map, position: markerPosition }); // 지도 마커 표시
+    markers.forEach((marker) => {
+      const markerPosition = new kakao.maps.LatLng(Number(marker.mapY), Number(marker.mapX));
+      new kakao.maps.Marker({ map, position: markerPosition, title: marker.title });
+    });
+  }, [markers]);
 
-    // const staticOptions = {
-    //   center: new kakao.maps.LatLng(33.450701, 126.570667), // 이미지 지도의 중심좌표
-    //   level: 3, // 이미지 지도의 확대 레벨
-    // };
-
-    // const staticMap = new kakao.maps.staticMap(staticContainer, staticOptions);
-    // console.log(staticMap);
-    // new kakao.maps.Marker({ staticMap, position: markerPosition });
-
-    // 마커 클릭 시 카카오 지도 오픈
-    // kakao.maps.event.addListener(marker, "click", function () {
-    //   handleOpenNewTab(
-    //     "https://map.kakao.com/link/map/37.56637787425258,126.97827585270615"
-    //   );
-    // });
-
-    // 커스텀 오버레이 - https://apis.map.kakao.com/web/sample/roadviewCustomOverlay/
-  }, []);
   return <div id="staticMap" ref={container} style={{ width: "100%", height: "100%" }}></div>;
 }

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -14,14 +14,21 @@ export default function CustomMap({ markers }: MapProps) {
         Number(centerY) || 37.56637787425258,
         Number(centerX) || 126.97827585270615,
       ),
-      level: 5,
+      level: 10,
     };
     const map = new kakao.maps.Map(container.current, options);
-
-    markers.forEach((marker) => {
-      const markerPosition = new kakao.maps.LatLng(Number(marker.mapY), Number(marker.mapX));
-      new kakao.maps.Marker({ map, position: markerPosition, title: marker.title });
+    const clusterer = new kakao.maps.MarkerClusterer({
+      map: map, // 마커들을 클러스터로 관리하고 표시할 지도 객체
+      averageCenter: true, // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
+      minLevel: 10, // 클러스터 할 최소 지도 레벨
     });
+
+    clusterer.addMarkers(
+      markers.map((marker) => {
+        const markerPosition = new kakao.maps.LatLng(Number(marker.mapY), Number(marker.mapX));
+        return new kakao.maps.Marker({ map, position: markerPosition, title: marker.title });
+      }),
+    );
   }, [markers]);
 
   return <div id="staticMap" ref={container} style={{ width: "100%", height: "100%" }}></div>;

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -1,11 +1,27 @@
-import { MapProps } from "types/common";
+import { MapProps, TourApiResponse } from "types/common";
 import { useEffect, useRef } from "react";
 import { PATH } from "@constants/path";
+import { useNavigate } from "react-router";
 
 const { kakao } = window;
 
-export default function CustomMap({ markers }: MapProps) {
+export default function CustomMap({ markers, type }: MapProps) {
+  const navigate = useNavigate();
   const container = useRef(null);
+
+  const NavigateTo = (item: TourApiResponse) => {
+    switch (type) {
+      case "camping":
+        navigate(PATH.campingInfo(item.contentid), { state: { item } });
+        break;
+      case "event":
+        navigate(PATH.eventInfo(item.contentid));
+        break;
+      case "restaurant":
+        navigate(PATH.restaurantInfo(item.contentid));
+        break;
+    }
+  };
 
   useEffect(() => {
     const { mapX: centerX, mapY: centerY } = markers[0];
@@ -26,6 +42,7 @@ export default function CustomMap({ markers }: MapProps) {
 
     clusterer.addMarkers(
       markers.map((data) => {
+        console.log(data);
         const markerPosition = new kakao.maps.LatLng(Number(data.mapY), Number(data.mapX));
         const marker = new kakao.maps.Marker({
           map,
@@ -41,16 +58,16 @@ export default function CustomMap({ markers }: MapProps) {
           '<div class="rounded absolute left-0 bottom-14 drop-shadow -translate-x-1/2">' +
           '    <div class="after:absolute after:left-1/2 after:-translate-x-1/2 after:border-[10px] after:border-b-0 after:border-x-transparent after:border-white">' +
           '        <div class="flex justify-between items-center bg-gray-scale-100 py-1 px-2 text-sub-title">' +
-          data.title +
+          data.facltNm +
           '<img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/overlay_close.png" id="close" class="w-4 h-4 hover:cursor-pointer" />' +
           "        </div>" +
           '        <div class="p-2 overflow-hidden bg-white flex flex-col gap-1">' +
           '            <div class="img w-full">' +
-          `<img src="${data.img}">` +
+          `<img src="${data.firstImageUrl}">` +
           "           </div>" +
           '            <div class="desc flex flex-col text-[15px]">' +
-          `                <div class="ellipsis">${data.addr}</div>` +
-          `<a href=${PATH.campingInfo(data.id)} class="text-primary-500 mt-3 ml-auto">바로가기</a>` +
+          `                <div class="ellipsis">${data.addr1}</div>` +
+          `<div id="navigation" class="text-primary-500 mt-3 ml-auto">바로가기</div>` +
           "            </div>" +
           "        </div>" +
           "    </div>" +
@@ -66,6 +83,9 @@ export default function CustomMap({ markers }: MapProps) {
         });
         content.querySelector("#close")?.addEventListener("click", function () {
           overlay.setMap(null);
+        });
+        content.querySelector("#navigation")?.addEventListener("click", function () {
+          NavigateTo(data);
         });
 
         return marker;

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -24,14 +24,9 @@ export default function CustomMap({ markers, type }: MapProps) {
   };
 
   useEffect(() => {
-    const { mapX: centerX, mapY: centerY } = markers[0];
-
     const options = {
-      center: new kakao.maps.LatLng(
-        Number(centerY) || 37.56637787425258,
-        Number(centerX) || 126.97827585270615,
-      ),
-      level: 10,
+      center: new kakao.maps.LatLng(36.134327437166306, 127.90256066256774),
+      level: 13,
     };
     const map = new kakao.maps.Map(container.current, options);
     const clusterer = new kakao.maps.MarkerClusterer({
@@ -42,12 +37,11 @@ export default function CustomMap({ markers, type }: MapProps) {
 
     clusterer.addMarkers(
       markers.map((data) => {
-        console.log(data);
         const markerPosition = new kakao.maps.LatLng(Number(data.mapY), Number(data.mapX));
         const marker = new kakao.maps.Marker({
           map,
           position: markerPosition,
-          title: data.title,
+          title: data.facltNm,
           clickable: true,
         });
 

--- a/src/components/common/search/CustomMap.tsx
+++ b/src/components/common/search/CustomMap.tsx
@@ -1,5 +1,6 @@
 import { MapProps } from "types/common";
 import { useEffect, useRef } from "react";
+import { PATH } from "@constants/path";
 
 const { kakao } = window;
 
@@ -24,9 +25,50 @@ export default function CustomMap({ markers }: MapProps) {
     });
 
     clusterer.addMarkers(
-      markers.map((marker) => {
-        const markerPosition = new kakao.maps.LatLng(Number(marker.mapY), Number(marker.mapX));
-        return new kakao.maps.Marker({ map, position: markerPosition, title: marker.title });
+      markers.map((data) => {
+        const markerPosition = new kakao.maps.LatLng(Number(data.mapY), Number(data.mapX));
+        const marker = new kakao.maps.Marker({
+          map,
+          position: markerPosition,
+          title: data.title,
+          clickable: true,
+        });
+
+        // const close = document.createElement("div")
+
+        const content = document.createElement("div");
+        content.innerHTML =
+          '<div class="rounded absolute left-0 bottom-14 drop-shadow -translate-x-1/2">' +
+          '    <div class="after:absolute after:left-1/2 after:-translate-x-1/2 after:border-[10px] after:border-b-0 after:border-x-transparent after:border-white">' +
+          '        <div class="flex justify-between items-center bg-gray-scale-100 py-1 px-2 text-sub-title">' +
+          data.title +
+          '<img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/overlay_close.png" id="close" class="w-4 h-4 hover:cursor-pointer" />' +
+          "        </div>" +
+          '        <div class="p-2 overflow-hidden bg-white flex flex-col gap-1">' +
+          '            <div class="img w-full">' +
+          `<img src="${data.img}">` +
+          "           </div>" +
+          '            <div class="desc flex flex-col text-[15px]">' +
+          `                <div class="ellipsis">${data.addr}</div>` +
+          `<a href=${PATH.campingInfo(data.id)} class="text-primary-500 mt-3 ml-auto">바로가기</a>` +
+          "            </div>" +
+          "        </div>" +
+          "    </div>" +
+          "</div>";
+
+        const overlay = new kakao.maps.CustomOverlay({
+          content: content,
+          position: marker.getPosition(),
+        });
+
+        kakao.maps.event.addListener(marker, "click", function () {
+          overlay.setMap(map);
+        });
+        content.querySelector("#close")?.addEventListener("click", function () {
+          overlay.setMap(null);
+        });
+
+        return marker;
       }),
     );
   }, [markers]);

--- a/src/components/common/search/SearchMap.tsx
+++ b/src/components/common/search/SearchMap.tsx
@@ -9,7 +9,7 @@ import {
 import CustomMap from "./CustomMap";
 import { MapProps } from "types/common";
 
-export default function SearchMap({ markers }: MapProps) {
+export default function SearchMap({ markers, type }: MapProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -27,7 +27,7 @@ export default function SearchMap({ markers }: MapProps) {
           <DialogTitle>Share link</DialogTitle>
           <DialogDescription>Anyone who has this link will be able to view this.</DialogDescription>
         </DialogHeader>
-        <CustomMap markers={markers} />
+        <CustomMap markers={markers} type={type} />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/common/search/SearchMap.tsx
+++ b/src/components/common/search/SearchMap.tsx
@@ -1,15 +1,33 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@components/ui/Dialog";
+import CustomMap from "./CustomMap";
+
 export default function SearchMap() {
   return (
-    <div className="relative">
-      <img src="/images/map-small.png" alt="map small" />
-      <div
-        className="absolute top-0 w-full h-full flex items-center justify-center"
-        onClick={() => alert("see map")}
-      >
-        <div className="w-fit text-xl bg-info-500 text-gray-scale-100 rounded px-[23px] py-[13px]">
-          지도 보기
+    <Dialog>
+      <DialogTrigger asChild>
+        <div className="relative">
+          <img src="/images/map-small.png" alt="map small" />
+          <div className="absolute top-0 w-full h-full flex items-center justify-center">
+            <div className="w-fit text-xl bg-info-500 text-gray-scale-100 rounded px-[23px] py-[13px]">
+              지도 보기
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      </DialogTrigger>
+      <DialogContent className="h-full">
+        <DialogHeader>
+          <DialogTitle>Share link</DialogTitle>
+          <DialogDescription>Anyone who has this link will be able to view this.</DialogDescription>
+        </DialogHeader>
+        <CustomMap />
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/common/search/SearchMap.tsx
+++ b/src/components/common/search/SearchMap.tsx
@@ -7,8 +7,9 @@ import {
   DialogTrigger,
 } from "@components/ui/Dialog";
 import CustomMap from "./CustomMap";
+import { MapProps } from "types/common";
 
-export default function SearchMap() {
+export default function SearchMap({ markers }: MapProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -26,7 +27,7 @@ export default function SearchMap() {
           <DialogTitle>Share link</DialogTitle>
           <DialogDescription>Anyone who has this link will be able to view this.</DialogDescription>
         </DialogHeader>
-        <CustomMap />
+        <CustomMap markers={markers} />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/common/search/SearchMap.tsx
+++ b/src/components/common/search/SearchMap.tsx
@@ -9,6 +9,12 @@ import {
 import CustomMap from "./CustomMap";
 import { MapProps } from "types/common";
 
+const LABEL = {
+  camping: "캠핑",
+  event: "행사",
+  restaurant: "음식점",
+};
+
 export default function SearchMap({ markers, type }: MapProps) {
   return (
     <Dialog>
@@ -24,8 +30,10 @@ export default function SearchMap({ markers, type }: MapProps) {
       </DialogTrigger>
       <DialogContent className="h-full">
         <DialogHeader>
-          <DialogTitle>Share link</DialogTitle>
-          <DialogDescription>Anyone who has this link will be able to view this.</DialogDescription>
+          <DialogTitle>{`${LABEL[type]} 지도 상세보기`}</DialogTitle>
+          <DialogDescription>
+            지도에서 한눈에 확인하고, 위치별 정보를 바로 확인하세요!
+          </DialogDescription>
         </DialogHeader>
         <CustomMap markers={markers} type={type} />
       </DialogContent>

--- a/src/components/detail/DetailRight.tsx
+++ b/src/components/detail/DetailRight.tsx
@@ -1,3 +1,5 @@
+import SpotMapSection from "./SpotMapSection";
+
 interface DetailRightProps {
   category: string;
   title: string;
@@ -6,6 +8,8 @@ interface DetailRightProps {
   contenttypeid: string;
   bookmarked: boolean;
   overview: string;
+  mapX: string;
+  mapY: string;
   opentimefood?: string;
   firstmenu?: string;
   infocenterfood?: string;
@@ -27,6 +31,8 @@ export default function DetailRight({
   contenttypeid,
   bookmarked = false,
   overview,
+  mapX,
+  mapY,
   opentimefood,
   firstmenu,
   parkingfood,
@@ -198,7 +204,7 @@ export default function DetailRight({
         </div>
       </div>
       <div className="w-full h-[318px] bg-gray-scale-100 rounded-xl overflow-hidden self-end">
-        <img src="/images/map-mid.png" alt="[임시] 지도 이미지" className="w-full object-cover" />
+        <SpotMapSection mapX={mapX} mapY={mapY} />
       </div>
     </article>
   );

--- a/src/components/detail/SpotAboutSection.tsx
+++ b/src/components/detail/SpotAboutSection.tsx
@@ -2,12 +2,16 @@
 //   [key: string]: T;
 // }
 
+import SpotMapSection from "./SpotMapSection";
+
 interface CampingDetailProps {
   shortIntro: string;
   description: string;
   campingFacilities: string;
   nearbyFacilities: string;
   homepage: string;
+  mapX: string;
+  mapY: string;
 }
 
 export default function SpotAboutSection({
@@ -16,6 +20,8 @@ export default function SpotAboutSection({
   campingFacilities,
   nearbyFacilities,
   homepage,
+  mapX,
+  mapY,
 }: CampingDetailProps) {
   return (
     <section className="grid grid-cols-12 mb-14">
@@ -56,7 +62,7 @@ export default function SpotAboutSection({
         </div>
       </div>
       <div className="col-start-7 -col-end-1 w-full h-[400px] bg-gray-scale-100 rounded-xl overflow-hidden">
-        <img src="/images/map-large.png" alt="[임시] 지도 이미지" className="w-full object-cover" />
+        <SpotMapSection mapX={mapX} mapY={mapY} />
       </div>
     </section>
   );

--- a/src/components/detail/SpotMapSection.tsx
+++ b/src/components/detail/SpotMapSection.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+const { kakao } = window;
+
+interface SpotMapSectionProps {
+  mapX: string;
+  mapY: string;
+}
+
+export default function SpotMapSection({ mapX, mapY }: SpotMapSectionProps) {
+  useEffect(() => {
+    const container = document.getElementById("staticMap");
+    const markerPosition = new kakao.maps.LatLng(mapY, mapX); // 지도 마커 위치
+    const marker = {
+      position: markerPosition,
+    };
+
+    const staticOptions = {
+      center: new kakao.maps.LatLng(mapY, mapX), // 이미지 지도의 중심좌표
+      level: 3, // 이미지 지도의 확대 레벨
+      marker,
+    };
+
+    new kakao.maps.StaticMap(container, staticOptions);
+  }, []);
+
+  return <div id="staticMap" style={{ width: "100%", height: "100%" }}></div>;
+}

--- a/src/components/detail/SpotMapSection.tsx
+++ b/src/components/detail/SpotMapSection.tsx
@@ -10,19 +10,19 @@ interface SpotMapSectionProps {
 export default function SpotMapSection({ mapX, mapY }: SpotMapSectionProps) {
   useEffect(() => {
     const container = document.getElementById("staticMap");
-    const markerPosition = new kakao.maps.LatLng(mapY, mapX); // 지도 마커 위치
+    const markerPosition = new kakao.maps.LatLng(mapY, mapX);
     const marker = {
       position: markerPosition,
     };
 
     const staticOptions = {
-      center: new kakao.maps.LatLng(mapY, mapX), // 이미지 지도의 중심좌표
-      level: 3, // 이미지 지도의 확대 레벨
+      center: new kakao.maps.LatLng(mapY, mapX),
+      level: 3,
       marker,
     };
 
     new kakao.maps.StaticMap(container, staticOptions);
-  }, []);
+  }, [mapX, mapY]);
 
   return <div id="staticMap" style={{ width: "100%", height: "100%" }}></div>;
 }

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@utils/style";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 flex flex-col w-11/12 translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/pages/CampingDetail.tsx
+++ b/src/pages/CampingDetail.tsx
@@ -30,6 +30,8 @@ interface campingDataResponse {
   contentId: string;
   facltNm: string;
   lineIntro: string;
+  mapX: string;
+  mapY: string;
 }
 
 const ReviewData: ReviewCardProps[] = [
@@ -125,6 +127,8 @@ export default function CampingDetail() {
         campingFacilities={CampingDetailData.sbrsCl}
         nearbyFacilities={CampingDetailData.posblFcltyCl}
         homepage={CampingDetailData.homepage}
+        mapX={CampingDetailData.mapX}
+        mapY={CampingDetailData.mapY}
       />
       <NearbyPlacesSection />
       <div className="mb-[200px]">

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -122,13 +122,7 @@ export default function CampingSearch() {
 
       <div className="flex gap-[34px] pb-5">
         <div className="flex flex-col gap-[30px]">
-          <SearchMap
-            markers={campingData.map((data) => ({
-              title: data.facltNm,
-              mapX: data.mapX,
-              mapY: data.mapY,
-            }))}
-          />
+          <SearchMap markers={campingData} type="camping" />
 
           <div className="flex flex-col gap-5">
             <h3 className="text-xl font-bold">필터</h3>

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -122,7 +122,13 @@ export default function CampingSearch() {
 
       <div className="flex gap-[34px] pb-5">
         <div className="flex flex-col gap-[30px]">
-          <SearchMap />
+          <SearchMap
+            markers={campingData.map((data) => ({
+              title: data.facltNm,
+              mapX: data.mapX,
+              mapY: data.mapY,
+            }))}
+          />
 
           <div className="flex flex-col gap-5">
             <h3 className="text-xl font-bold">필터</h3>

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -158,6 +158,8 @@ export default function EventDetail() {
           addr2={eventDetailData.addr2}
           eventhomepage={eventDetailData.homepage}
           overview={eventDetailData.overview}
+          mapX={eventDetailData.mapx}
+          mapY={eventDetailData.mapy}
         />
       </section>
       <NearbyPlacesSection />

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -102,14 +102,16 @@ export default function EventDetail() {
           overviewYN: "Y",
           areacodeYN: "Y",
           addrinfoYN: "Y",
+          mapinfoYN: "Y",
         },
       });
 
       const item: CommonDetails = Array.isArray(commonResponse.data.response.body.items.item)
         ? commonResponse.data.response.body.items.item[0]
         : commonResponse.data.response.body.items.item;
-      const { title, addr1, addr2, homepage, overview, contentid, contenttypeid } = item;
-      return { title, addr1, addr2, homepage, overview, contentid, contenttypeid };
+      const { title, addr1, addr2, homepage, overview, contentid, contenttypeid, mapx, mapy } =
+        item;
+      return { title, addr1, addr2, homepage, overview, contentid, contenttypeid, mapx, mapy };
     } catch (error) {
       setError("이벤트 상세 정보를 가져오는 중 오류가 발생했습니다.");
       console.error("Error fetching event detail data:", error);

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -125,7 +125,6 @@ export default function EventDetail() {
       const common = await fetchEventCommonData();
 
       if (images && detail && common) {
-        console.log({ images, ...detail, ...common });
         setEventDetailData({ images, ...detail, ...common });
       }
       setIsLoading(false);

--- a/src/pages/EventSearch.tsx
+++ b/src/pages/EventSearch.tsx
@@ -163,7 +163,17 @@ export default function EventSearch() {
       </div>
       <div className="flex gap-[34px]">
         <div className="flex flex-col gap-[30px]">
-          <SearchMap />
+          <SearchMap
+            markers={events.map((event) => ({
+              addr1: event.addr1,
+              contentid: event.contentid,
+              facltNm: event.title,
+              firstImageUrl: event.firstimage,
+              mapX: event.mapx,
+              mapY: event.mapy,
+            }))}
+            type="event"
+          />
           <div className="flex flex-col gap-5">
             <h3 className="text-xl font-bold">필터</h3>
             <CheckboxList categories={EVENT_PROGRESS} title="진행/예정" />

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -122,7 +122,7 @@ export default function FoodDetail() {
       const imgItems = responseImg.data.response.body.items.item;
       const detailCommonItems = responseDetailCommon.data.response.body.items.item;
       const introItems = responseIntro.data.response.body.items.item;
-      console.log(imgItems);
+      console.log(1, detailCommonItems);
 
       setRestaurantImgList(imgItems);
       setRestaurantData({ common: detailCommonItems, intro: introItems });
@@ -140,10 +140,13 @@ export default function FoodDetail() {
     fetchRestaurantsDetail();
   }, [fetchRestaurantsDetail]);
 
+  if (isLoading) return <p>로딩중...</p>;
+  if (error) return <p>{error}</p>;
+  if (!restaurantData.intro.length || !restaurantData.common.length)
+    return <p>데이터를 불러오지 못했습니다.</p>;
+
   return (
     <>
-      {isLoading && "로딩중.."}
-      {error}
       <section className="mt-20 w-full flex gap-11 mb-14">
         {restaurantImg !== undefined ? (
           <DetailLeft
@@ -171,6 +174,8 @@ export default function FoodDetail() {
           firstmenu={restaurantData.intro[0]?.firstmenu || ""}
           parkingfood={restaurantData.intro[0]?.parkingfood || "유료 주차장 1시간무료"}
           restdatefood={restaurantData.intro[0]?.restdatefood || "연중무휴"}
+          mapX={restaurantData.common[0].mapx}
+          mapY={restaurantData.common[0].mapy}
         />
       </section>
       <NearbyPlacesSection />

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -4,7 +4,6 @@ import DetailLeft from "@components/detail/DetailLeft";
 import DetailRight from "@components/detail/DetailRight";
 import NearbyPlacesSection from "@components/detail/NearbyPlacesSection";
 
-
 import { PATH } from "@constants/path";
 import { useParams } from "react-router";
 import { tourApiInstance } from "@utils/axiosInstance";
@@ -122,12 +121,9 @@ export default function FoodDetail() {
       const imgItems = responseImg.data.response.body.items.item;
       const detailCommonItems = responseDetailCommon.data.response.body.items.item;
       const introItems = responseIntro.data.response.body.items.item;
-      console.log(1, detailCommonItems);
 
       setRestaurantImgList(imgItems);
       setRestaurantData({ common: detailCommonItems, intro: introItems });
-
-      console.log(detailCommonItems);
     } catch (error) {
       setError("데이터를 불러오는데 실패하였습니다.");
       console.error("Error fetching data:", error);

--- a/src/pages/RestaurantSearch.tsx
+++ b/src/pages/RestaurantSearch.tsx
@@ -163,7 +163,17 @@ export default function RestaurantSearch() {
 
       <div className="flex gap-[34px] pb-5">
         <div className="flex flex-col gap-[30px]">
-          <SearchMap />
+          <SearchMap
+            markers={restaurants.map((rest) => ({
+              addr1: rest.addr1,
+              contentid: rest.contentid,
+              facltNm: rest.title,
+              firstImageUrl: rest.firstimage,
+              mapX: rest.mapx,
+              mapY: rest.mapy,
+            }))}
+            type="restaurant"
+          />
 
           <div className="flex flex-col gap-5">
             <h3 className="text-xl font-bold">필터</h3>

--- a/src/pages/RestaurantSearch.tsx
+++ b/src/pages/RestaurantSearch.tsx
@@ -97,7 +97,6 @@ export default function RestaurantSearch() {
 
       const items = response.data.response.body.items.item || [];
 
-      console.log(items);
       setRestaurants(items);
     } catch (error) {
       console.log(error);

--- a/src/types/CampingDataResponse.ts
+++ b/src/types/CampingDataResponse.ts
@@ -1,4 +1,6 @@
-interface campingDataResponse {
+import { TourApiResponse } from "./common";
+
+interface campingDataResponse extends TourApiResponse {
   sbrsCl: string;
   posblFcltyCl: string;
   featureNm: string;

--- a/src/types/EventResponse.ts
+++ b/src/types/EventResponse.ts
@@ -70,4 +70,6 @@ export interface EventDetailData {
   eventenddate: string;
   overview: string;
   images: string[];
+  mapx: string;
+  mapy: string;
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -3,4 +3,14 @@ interface FilterCategory {
   label: string;
 }
 
-export type { FilterCategory };
+interface MapMarker {
+  title: string;
+  mapX: string;
+  mapY: string;
+}
+
+interface MapProps {
+  markers: MapMarker[];
+}
+
+export type { FilterCategory, MapMarker, MapProps };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -3,14 +3,27 @@ interface FilterCategory {
   label: string;
 }
 
-interface MapMarker {
-  title: string;
+interface TourApiResponse {
+  addr1: string;
+  firstImageUrl: string;
+  facltNm: string;
+  contentid: string;
   mapX: string;
   mapY: string;
 }
 
-interface MapProps {
-  markers: MapMarker[];
+interface MapMarker {
+  id: string;
+  title: string;
+  mapX: string;
+  mapY: string;
+  addr: string;
+  img: string;
 }
 
-export type { FilterCategory, MapMarker, MapProps };
+interface MapProps {
+  markers: TourApiResponse[];
+  type: "camping" | "event" | "restaurant";
+}
+
+export type { FilterCategory, MapMarker, MapProps, TourApiResponse };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,3 +9,8 @@ interface ImportMeta {
     VITE_KAKAO_API_KEY: string;
   };
 }
+
+interface Window {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  kakao: any;
+}


### PR DESCRIPTION
- #127 

## 💡 변경사항 & 이슈
지도 api 적용
<br>

## ✍️ 관련 설명
### 검색 화면 지도 보기 모달 추가 및 지도 api 적용
![image](https://github.com/user-attachments/assets/2a535ea6-e8aa-4924-9be5-a78c90b8645d)
마커를 클릭하면 장소에 대한 오버레이가 생성됩니다.

### 장소 오버레이
![image](https://github.com/user-attachments/assets/def14de6-7b1f-4235-be77-9aa9b2fa9bd6)

### 상세 페이지 지도 적용
![image](https://github.com/user-attachments/assets/5cd39ae3-dec9-4a8d-a097-b6a48415a051)
![image](https://github.com/user-attachments/assets/3e0eb45f-5782-47f4-9514-363628402bb7)
![image](https://github.com/user-attachments/assets/b645c717-9bcd-49f8-866f-d03d84973d89)
정적으로 이동 없이 지도를 보여줍니다. 지도를 클릭하면 카카오 지도로 자동 이동됩니다.

<br>

## ⭐️ Review point
지도 모달의 문구는 임의로 지정한 것이어서 더 좋은 아이디어가 있다면 편하게 말씀해주세요.

장소 오버레이에서 추가적으로 표시됐으면 하는 정보가 있다면 말씀 부탁드립니다.

### 추가 사항
- 음식점은 한번에 너무 많은 데이터를 불러와서 그런지 약간 렉 걸릴 떄가 있습니다. 무한 스크롤이나 페이지네이션을 적용해서 조금씩 여러번 불러오는 것이 좋을 것 같네요!
- 행사 상세 페이지 홈페이지가 html 태그로 나오는 문제가 있습니다.


<br>

## 📷 Demo

<br>
