### PR TITLE
146 add related products section to shopping detail page

### DIFF
--- a/src/components/detail/DetailRight.tsx
+++ b/src/components/detail/DetailRight.tsx
@@ -42,14 +42,15 @@ export default function DetailRight({
   eventstartdate,
   eventenddate,
 }: DetailRightProps) {
-  const formatDate = (str) => `${str.slice(0, 4)}년 ${str.slice(4, 6)}월 ${str.slice(6, 8)}일`;
+  const formatDate = (str: string) =>
+    `${str.slice(0, 4)}년 ${str.slice(4, 6)}월 ${str.slice(6, 8)}일`;
 
   return (
     <article className="flex-1 flex flex-col">
       <div className="flex-1 flex flex-col gap-8">
         <div className="flex justify-between">
           <div className="flex flex-col gap-7">
-            <div className="">
+            <div className="w-96">
               <span className="text-sub-title text-gray-scale-300">{category}</span>
               <h3 className="text-highlight">{title}</h3>
             </div>
@@ -151,7 +152,8 @@ export default function DetailRight({
               <li className="mb-3">
                 <span className="block text-body1 text-gray-scale-400">
                   <strong className="mr-4 text-gray-scale-500">행사기간</strong>
-                  {formatDate(eventstartdate)} -{formatDate(eventenddate)}
+                  {eventstartdate && formatDate(eventstartdate)}
+                  {eventenddate && " - " + formatDate(eventenddate)}
                 </span>
               </li>
               <li className="mb-3">

--- a/src/components/detail/ProductInfo.tsx
+++ b/src/components/detail/ProductInfo.tsx
@@ -11,7 +11,7 @@ export default function ProductInfo({ product }: { product: NaverProductResponse
   };
 
   return (
-    <section className="flex justify-between">
+    <section className="flex justify-between mb-20 gap-16">
       <article className="w-[500px] h-[500px] border-2 rounded-xl bg-gray-scale-100 overflow-hidden">
         <img
           src={
@@ -22,9 +22,9 @@ export default function ProductInfo({ product }: { product: NaverProductResponse
           className="w-full h-full object-cover"
         />
       </article>
-      <article className="w-[550px] flex flex-col justify-between">
+      <article className="flex-1 flex flex-col justify-between">
         <div className="flex justify-between">
-          <div className="w-[400px]">
+          <div className="w-[500px]">
             <span className="text-sub-title text-gray-scale-300 mb-2">{brand || mallName}</span>
             <h4 className="text-title mb-4">{title.replace(/<\/?[^>]+(>|$)/g, "")}</h4>
             <span className="text-title font-bold">

--- a/src/components/shopping/ProductCardList.tsx
+++ b/src/components/shopping/ProductCardList.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import ProductCard from "./ProductCard";
-import { naverApiInstance } from "@utils/axiosInstance";
-import { NaverProductResponse, NaverSearchResponse } from "types/NaverShoppingResponse";
+import useNaverProduct from "@hooks/useNaverProduct";
 
 export default function ProductCardList({
   orderBy,
@@ -10,32 +9,11 @@ export default function ProductCardList({
   orderBy: string;
   keyword: string;
 }) {
-  const [products, setProducts] = useState<NaverProductResponse[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const fetchNaverProductData = useCallback(async () => {
-    setIsLoading(true);
-    setErrorMessage(null);
-
-    try {
-      const response = await naverApiInstance.get<NaverSearchResponse>("/shop.json", {
-        params: {
-          query: keyword,
-          display: 20,
-          start: 1,
-          sort: orderBy,
-        },
-      });
-
-      setProducts(response.data.items);
-    } catch (error) {
-      setErrorMessage("상품 데이터를 가져오는 중 오류가 발생했습니다.");
-      console.error("Error fetching product data:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [orderBy, keyword]);
+  const { products, isLoading, errorMessage, fetchNaverProductData } = useNaverProduct(
+    keyword,
+    20,
+    orderBy,
+  );
 
   useEffect(() => {
     fetchNaverProductData();

--- a/src/components/shopping/ProductCategories.tsx
+++ b/src/components/shopping/ProductCategories.tsx
@@ -1,0 +1,22 @@
+import { NaverProductResponse } from "types/NaverShoppingResponse";
+
+export default function ProductCategories({ product }: { product: NaverProductResponse }) {
+  return (
+    <section>
+      <ul className="flex gap-4">
+        <li className="w-64 text-center py-3 text-sub-title rounded-full bg-gray-scale-100/50">
+          {product.category1}
+        </li>
+        <li className="w-64 text-center py-3 text-sub-title rounded-full bg-gray-scale-100/50">
+          {product.category2}
+        </li>
+        <li className="w-64 text-center py-3 text-sub-title rounded-full bg-gray-scale-100/50">
+          {product.category3}
+        </li>
+        <li className="w-64 text-center py-3 text-sub-title rounded-full bg-gray-scale-100/50">
+          {product.category4}
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/src/components/shopping/RelatedProducts.tsx
+++ b/src/components/shopping/RelatedProducts.tsx
@@ -1,0 +1,35 @@
+import useNaverProduct from "@hooks/useNaverProduct";
+import { useEffect } from "react";
+import ProductCard from "./ProductCard";
+
+export default function RelatedProducts({ title, category }: { title: string; category: string }) {
+  const { products, isLoading, errorMessage, fetchNaverProductData } = useNaverProduct(category, 5);
+
+  useEffect(() => {
+    fetchNaverProductData();
+  }, [fetchNaverProductData]);
+
+  return (
+    <section className="my-12">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-title">{title}</h2>
+      </div>
+      {isLoading && <p>로딩중...</p>}
+      {errorMessage}
+      <div className="flex justify-between">
+        {products.length === 0 && (
+          <p className="text-sub-title text-gray-scale-300">관련 상품이 없습니다.</p>
+        )}
+        {products.length !== 0 &&
+          products.map((product) => (
+            <ProductCard
+              key={product.productId}
+              product={product}
+              bookmarked={false}
+              handleClickBookmark={() => alert("bookmark")}
+            />
+          ))}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useNaverProduct.ts
+++ b/src/hooks/useNaverProduct.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+import { naverApiInstance } from "@utils/axiosInstance";
+import { NaverProductResponse, NaverSearchResponse } from "types/NaverShoppingResponse";
+const useNaverProduct = (keyword: string, count: number, orderBy: string = "sim") => {
+  const [products, setProducts] = useState<NaverProductResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchNaverProductData = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await naverApiInstance.get<NaverSearchResponse>("/shop.json", {
+        params: {
+          query: keyword,
+          display: count,
+          start: 1,
+          sort: orderBy,
+        },
+      });
+
+      setProducts(response.data.items);
+    } catch (error) {
+      setErrorMessage("상품 데이터를 가져오는 중 오류가 발생했습니다.");
+      console.error("Error fetching product data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [orderBy, count, keyword]);
+
+  return {
+    products,
+    isLoading,
+    errorMessage,
+    fetchNaverProductData,
+  };
+};
+
+export default useNaverProduct;

--- a/src/pages/ShoppingDetail.tsx
+++ b/src/pages/ShoppingDetail.tsx
@@ -1,12 +1,26 @@
 import ProductInfo from "@components/detail/ProductInfo";
+import RelatedProducts from "@components/shopping/RelatedProducts";
+import { NaverProductResponse } from "types/NaverShoppingResponse";
 import { useLocation } from "react-router";
+import ProductCategories from "@components/shopping/ProductCategories";
 
 export default function ShoppingDetail() {
   const location = useLocation();
+  const product = location.state as NaverProductResponse;
 
   return (
-    <div className="w-[1100px] mx-auto mt-20">
-      <ProductInfo product={location.state} />
+    <div className="w-[1200px] mx-auto mt-20">
+      <ProductInfo product={product} />
+      <ProductCategories product={product} />
+      <RelatedProducts
+        title="비슷한 상품"
+        category={product.category1 + product.category2 + product.category3}
+      />
+      <hr />
+      <RelatedProducts
+        title="BRAND"
+        category={product.brand || product.title.replace(/<\/?[^>]+(>|$)/g, "").slice(0, 2)}
+      />
     </div>
   );
 }

--- a/src/pages/ShoppingMain.tsx
+++ b/src/pages/ShoppingMain.tsx
@@ -260,16 +260,16 @@ export default function ShoppingMain() {
   return (
     <div className="flex flex-col gap-[60px]">
       {/* Banner */}
-      <div className="relative">
+      <section className="relative">
         <img src="/images/shopping/shopping-banner.png" alt="banner" className="w-full" />
         <SearchBar
           handleSubmit={(input) => handleSearch(input)}
           className="absolute bottom-[60px] left-[50%] -translate-x-[50%]"
         />
-      </div>
+      </section>
 
       {/* Category */}
-      <div>
+      <section>
         <div className="flex justify-between items-center">
           <SubTitle>카테고리별 분류</SubTitle>
           <button className="text-sub-title text-info-500">더보기</button>
@@ -282,10 +282,10 @@ export default function ShoppingMain() {
           <CategoryCard src="/images/shopping/camping-furniture.png" catName="캠핑 가구" />
           <CategoryCard src="/images/shopping/bonfire.png" catName="소모품" />
         </div>
-      </div>
+      </section>
 
       {/* Recommend */}
-      <div>
+      <section>
         <div className="flex justify-between items-center">
           <SubTitle>오늘의 추천 상품</SubTitle>
           <button className="text-sub-title text-info-500">더보기</button>
@@ -300,10 +300,10 @@ export default function ShoppingMain() {
             />
           ))}
         </div>
-      </div>
+      </section>
 
       {/* NewProduct */}
-      <div>
+      <section>
         <div className="flex justify-between items-center">
           <SubTitle>신상품</SubTitle>
           <button className="text-sub-title text-info-500">더보기</button>
@@ -318,10 +318,10 @@ export default function ShoppingMain() {
             />
           ))}
         </div>
-      </div>
+      </section>
 
       {/* Sale */}
-      <div className="relative">
+      <section className="relative">
         <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-[#E8F6F1] w-screen h-[450px] -z-10"></div>
         <div className="flex justify-between items-center">
           <SubTitle>최저가 득템!</SubTitle>
@@ -337,10 +337,10 @@ export default function ShoppingMain() {
             />
           ))}
         </div>
-      </div>
+      </section>
 
       {/* Review */}
-      <div>
+      <section>
         <div className="flex justify-between items-center">
           <SubTitle>포토 리뷰 모음집</SubTitle>
           <button className="text-sub-title text-info-500">더보기</button>
@@ -357,7 +357,7 @@ export default function ShoppingMain() {
             />
           ))}
         </div>
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
- #146

## 💡 변경사항 & 이슈
쇼핑 상세페이지 하단에 관련 섹션들 추가하였습니다.

<br>

## ✍️ 관련 설명
### 상품 카테고리 섹션
![image](https://github.com/user-attachments/assets/b2489e73-fffd-429d-95a8-a58bbc6ccf0d)


### 관련 상품 섹션
![image](https://github.com/user-attachments/assets/08dfc0fe-81d6-423d-bbb3-ac95ac151ae6)


### 브랜드 상품 섹션
![image](https://github.com/user-attachments/assets/92997b86-c3b1-4363-89bd-17d2dc7711a8)



<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
