### PR TITLE
143 implementing member info modification

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%&libraries=clusterer"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_API_KEY%&libraries=clusterer"
     ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>

--- a/src/components/layouts/MainNavigation.tsx
+++ b/src/components/layouts/MainNavigation.tsx
@@ -39,7 +39,7 @@ export default function MainNavigation({ token }: { token: string }) {
       ) : (
         <div className="flex gap-5 items-center text-sub-title font-normal">
           <Link
-            to={PATH.activities}
+            to={PATH.information}
             className="w-10 h-10 rounded-full bg-gray-scale-100 flex items-center justify-center overflow-hidden"
           >
             <img src="/public/vite.svg" alt="프로필 이미지" className="size-full object-cover" />

--- a/src/components/layouts/RootLayout.tsx
+++ b/src/components/layouts/RootLayout.tsx
@@ -3,6 +3,7 @@ import MainNavigation from "./MainNavigation";
 import "swiper/css";
 import { useEffect } from "react";
 import { getTokenDuration } from "@utils/authToken";
+import AuthProvider from "@hooks/useAuth/AuthProvider";
 
 export default function RootLayout() {
   const token = useLoaderData();
@@ -26,13 +27,15 @@ export default function RootLayout() {
   }, [token, submit]);
 
   return (
-    <div className="min-h-dvh">
-      <div className="font-sans">
-        <header className="sticky top-0 bg-gray-scale-0 py-3 z-20">
-          <MainNavigation token={token} />
-        </header>
-        <Outlet />
+    <AuthProvider>
+      <div className="min-h-dvh">
+        <div className="font-sans">
+          <header className="sticky top-0 bg-gray-scale-0 py-3 z-20">
+            <MainNavigation token={token} />
+          </header>
+          <Outlet />
+        </div>
       </div>
-    </div>
+    </AuthProvider>
   );
 }

--- a/src/components/mypage/InputField.tsx
+++ b/src/components/mypage/InputField.tsx
@@ -5,7 +5,7 @@ interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
 
 export default function InputField({ error, label, name, ...props }: InputFieldProps) {
   return (
-    <div className="relative">
+    <div>
       <label htmlFor={name} className="text-body1">
         {label}
       </label>

--- a/src/components/mypage/InputField.tsx
+++ b/src/components/mypage/InputField.tsx
@@ -1,0 +1,22 @@
+interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: string;
+  label: string;
+}
+
+export default function InputField({ error, label, name, ...props }: InputFieldProps) {
+  return (
+    <div className="relative">
+      <label htmlFor={name} className="text-body1">
+        {label}
+      </label>
+      <div className="mt-2">
+        <input
+          {...props}
+          name={name}
+          className="w-full bg-gray-scale-100 rounded-md mt-[10px] p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:text-gray-scale-500"
+        />
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuth/AuthContext.tsx
+++ b/src/hooks/useAuth/AuthContext.tsx
@@ -7,7 +7,7 @@ interface AuthContextType {
   login: (userData: User) => void;
   logout: () => void;
   updateUser: () => void;
-  modifyUser: (userData: UserInfoState) => void;
+  modifyUser: (userData: UserInfoState) => Promise<{ ok: boolean }>;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/hooks/useAuth/AuthContext.tsx
+++ b/src/hooks/useAuth/AuthContext.tsx
@@ -1,11 +1,13 @@
 import { User } from "types/AuthResponse";
 import { createContext } from "react";
+import { UserInfoState } from "@pages/MypageInfo";
 
 interface AuthContextType {
   user: User | null;
   login: (userData: User) => void;
   logout: () => void;
   updateUser: () => void;
+  modifyUser: (userData: UserInfoState) => void;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/hooks/useAuth/AuthContext.tsx
+++ b/src/hooks/useAuth/AuthContext.tsx
@@ -1,0 +1,13 @@
+import { User } from "types/AuthResponse";
+import { createContext } from "react";
+
+interface AuthContextType {
+  user: User | null;
+  login: (userData: User) => void;
+  logout: () => void;
+  updateUser: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export default AuthContext;

--- a/src/hooks/useAuth/AuthProvider.tsx
+++ b/src/hooks/useAuth/AuthProvider.tsx
@@ -1,0 +1,33 @@
+import { User } from "types/AuthResponse";
+import { useState, ReactNode } from "react";
+import { apiInstance } from "@utils/axiosInstance";
+import AuthContext from "./AuthContext";
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = (userData: User) => {
+    setUser(userData);
+  };
+
+  const logout = () => {
+    setUser(null);
+  };
+
+  const updateUser = async () => {
+    const token = localStorage.getItem("token");
+
+    const response = await apiInstance.get<User>(`/users/${user?._id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    setUser(response.data);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, updateUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/hooks/useAuth/AuthProvider.tsx
+++ b/src/hooks/useAuth/AuthProvider.tsx
@@ -42,7 +42,11 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       },
     );
 
-    setUser(response.data);
+    if (response.status === 200) {
+      setUser(response.data);
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.reject({ ok: false });
   };
 
   return (

--- a/src/hooks/useAuth/AuthProvider.tsx
+++ b/src/hooks/useAuth/AuthProvider.tsx
@@ -2,6 +2,7 @@ import { User } from "types/AuthResponse";
 import { useState, ReactNode } from "react";
 import { apiInstance } from "@utils/axiosInstance";
 import AuthContext from "./AuthContext";
+import { UserInfoState } from "@pages/MypageInfo";
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -25,8 +26,27 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     setUser(response.data);
   };
 
+  const modifyUser = async (userData: UserInfoState) => {
+    const token = localStorage.getItem("token");
+
+    const response = await apiInstance.put<User>(
+      "/settings/update-user",
+      {
+        fullName: JSON.stringify(userData),
+        username: userData.nickName,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    setUser(response.data);
+  };
+
   return (
-    <AuthContext.Provider value={{ user, login, logout, updateUser }}>
+    <AuthContext.Provider value={{ user, login, logout, updateUser, modifyUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useAuth/useAuth.tsx
+++ b/src/hooks/useAuth/useAuth.tsx
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import AuthContext from "./AuthContext";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) throw new Error("useAuth must be used within an AuthProvider");
+
+  return context;
+};

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -38,9 +38,12 @@ const useForm = ({ initialFormData, initialErrors = {}, validator }: UseFormOpti
           return validator.validateBirthMonth(value);
         case "birthDay":
           return validator.validateBirthDay(value);
+        case "birthDate":
+          return validator.validateBirthDate(value);
         case "phone":
           return validator.validatePhone(value);
         case "fullName":
+        case "nickName":
           return validator.validateFullName(value);
         default:
           return undefined;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import FormValidator from "@utils/FormValidator";
 import InputField from "@components/ui/InputField";
 import AuthResponse from "types/AuthResponse";
 import { useMemo } from "react";
+import { useAuth } from "@hooks/useAuth/useAuth";
 
 const TOKEN_EXPIRY_HOURS = 1;
 
@@ -26,6 +27,7 @@ const initializeFormData = () => ({
 export default function Login() {
   const navigate = useNavigate();
   const formValidator = useMemo(() => new FormValidator(), []);
+  const { login } = useAuth();
 
   const {
     formData,
@@ -60,6 +62,7 @@ export default function Login() {
 
         const resData = response.data;
         setAuthToken(resData.token);
+        login(resData.user);
 
         navigate(PATH.home);
       }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -79,13 +79,12 @@ export default function Login() {
 
   const VITE_KAKAO_API_KEY: string = import.meta.env.VITE_KAKAO_API_KEY;
   const VITE_GOOGLE_CLIENT_ID: string = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-  const VITE_NAVER_API_ID_KEY: string = import.meta.env.VITE_NAVER_API_ID_KEY;
+  const VITE_NAVER_API_ID_KEY: string = import.meta.env.VITE_NAVER_LOGIN_API_ID_KEY;
   const REDIRECT_URI = `${window.location.origin}${PATH.oauthRedirect}`;
   const kakao_link = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${VITE_KAKAO_API_KEY}&redirect_uri=${REDIRECT_URI}`;
   const google_link = `https://accounts.google.com/o/oauth2/auth?client_id=${VITE_GOOGLE_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=openid email profile`;
   const naver_link = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${VITE_NAVER_API_ID_KEY}&redirect_uri=${REDIRECT_URI}&state=naver`;
 
-  
   const loginWithKakao = () => {
     window.location.href = kakao_link;
   };

--- a/src/pages/MypageInfo.tsx
+++ b/src/pages/MypageInfo.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@hooks/useAuth/useAuth";
 
-type UserInfoState = {
+export type UserInfoState = {
   nickName: string;
   fullName: string;
   phone: string;
@@ -9,7 +9,7 @@ type UserInfoState = {
 };
 
 export default function Info() {
-  const { user, updateUser } = useAuth();
+  const { user, updateUser, modifyUser } = useAuth();
   const [userInfo, setUserInfo] = useState<UserInfoState>(
     (JSON.parse(user?.fullName || "") as UserInfoState) || {
       nickName: "",
@@ -24,9 +24,26 @@ export default function Info() {
     setUserInfo({ ...userInfo, [field]: value });
   };
 
+  const handleClick = () => {
+    if (isReadMode) {
+      setIsReadMode(false);
+    } else {
+      setIsReadMode(true);
+      saveUserInfo();
+    }
+  };
+
+  const saveUserInfo = () => {
+    modifyUser(userInfo);
+  };
+
   useEffect(() => {
     updateUser();
   }, []);
+
+  useEffect(() => {
+    setUserInfo(JSON.parse(user?.fullName || "") as UserInfoState);
+  }, [user]);
 
   return (
     <div className="rounded-lg">
@@ -34,7 +51,7 @@ export default function Info() {
         <h1 className="text-sub-title font-bold mb-6">내 정보 관리</h1>
         <div
           className="border border-primary-500 px-2 py-1 rounded text-body1 bg-primary-500 text-white hover:brightness-95 cursor-pointer"
-          onClick={() => setIsReadMode((prev) => !prev)}
+          onClick={handleClick}
         >
           {isReadMode ? "수정하기" : "저장하기"}
         </div>

--- a/src/pages/MypageInfo.tsx
+++ b/src/pages/MypageInfo.tsx
@@ -1,27 +1,44 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useAuth } from "@hooks/useAuth/useAuth";
 
 type UserInfoState = {
   nickName: string;
-  name: string;
+  fullName: string;
   phone: string;
-  birth: string;
+  birthDate: string;
 };
 
 export default function Info() {
-  const [userInfo, setUserInfo] = useState<UserInfoState>({
-    nickName: "",
-    name: "",
-    phone: "",
-    birth: "",
-  });
+  const { user, updateUser } = useAuth();
+  const [userInfo, setUserInfo] = useState<UserInfoState>(
+    (JSON.parse(user?.fullName || "") as UserInfoState) || {
+      nickName: "",
+      fullName: "",
+      phone: "",
+      birthDate: "",
+    },
+  );
+  const [isReadMode, setIsReadMode] = useState(true);
 
   const handleChange = (field: keyof UserInfoState, value: string) => {
     setUserInfo({ ...userInfo, [field]: value });
   };
 
+  useEffect(() => {
+    updateUser();
+  }, []);
+
   return (
     <div className="rounded-lg">
-      <h1 className="text-sub-title font-bold mb-6">내 정보 관리</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-sub-title font-bold mb-6">내 정보 관리</h1>
+        <div
+          className="border border-primary-500 px-2 py-1 rounded text-body1 bg-primary-500 text-white hover:brightness-95 cursor-pointer"
+          onClick={() => setIsReadMode((prev) => !prev)}
+        >
+          {isReadMode ? "수정하기" : "저장하기"}
+        </div>
+      </div>
 
       <div className="grid grid-cols-2 gap-4">
         <div className="relative">
@@ -33,20 +50,22 @@ export default function Info() {
             id="nickname"
             value={userInfo.nickName}
             onChange={(e) => handleChange("nickName", e.target.value)}
+            disabled={isReadMode}
             placeholder="현재 닉네임"
-            className="w-full bg-gray-scale-100 rounded-md mt-[10px] p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full bg-gray-scale-100 rounded-md mt-[10px] p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:text-gray-scale-500"
           />
         </div>
 
         <div className="relative">
-          <label htmlFor="name" className="text-body1">
+          <label htmlFor="fullName" className="text-body1">
             이름
           </label>
           <input
             type="text"
-            id="name"
-            value={userInfo.name}
-            onChange={(e) => handleChange("name", e.target.value)}
+            id="fullName"
+            value={userInfo.fullName}
+            onChange={(e) => handleChange("fullName", e.target.value)}
+            disabled={isReadMode}
             placeholder="홍길동"
             className="w-full border bg-gray-scale-100 rounded-md mt-[10px] p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
@@ -63,20 +82,22 @@ export default function Info() {
             id="phone"
             value={userInfo.phone}
             onChange={(e) => handleChange("phone", e.target.value)}
+            disabled={isReadMode}
             placeholder="0101234****"
             className="w-full border bg-gray-scale-100 rounded-md mt-[10px] p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div className="relative">
-          <label htmlFor="phone" className="text-body1">
+          <label htmlFor="birthDate" className="text-body1">
             생년월일
           </label>
           <input
             type="text"
-            id="birth"
-            value={userInfo.birth}
-            onChange={(e) => handleChange("birth", e.target.value)}
+            id="birthDate"
+            value={userInfo.birthDate}
+            onChange={(e) => handleChange("birthDate", e.target.value)}
+            disabled={isReadMode}
             placeholder="19**년 *월 *일"
             className="w-full border bg-gray-scale-100 rounded-md mt-[10px]  p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />

--- a/src/pages/MypageInfo.tsx
+++ b/src/pages/MypageInfo.tsx
@@ -59,7 +59,7 @@ export default function Info() {
   };
 
   return (
-    <div className="rounded-lg">
+    <div className="rounded-lg w-[740px]">
       <div className="flex justify-between items-center">
         <h1 className="text-sub-title font-bold mb-6">내 정보 관리</h1>
         <div

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -60,7 +60,12 @@ export default function SignUp() {
         password: formData.password,
         birthDate,
         phone: formData.phone.replace(/-/g, ""),
-        fullName: formData.fullName,
+        fullName: JSON.stringify({
+          fullName: formData.fullName,
+          birthDate,
+          phone: formData.phone.replace(/-/g, ""),
+          nickName: formData.fullName,
+        }),
       });
 
       if (response.status === 200 || response.status === 201) {

--- a/src/types/AuthResponse.ts
+++ b/src/types/AuthResponse.ts
@@ -107,3 +107,4 @@ interface AuthResponse {
 }
 
 export default AuthResponse;
+export type { User };

--- a/src/utils/FormValidator.ts
+++ b/src/utils/FormValidator.ts
@@ -62,6 +62,12 @@ class FormValidator {
     return undefined;
   }
 
+  // 생일 유효성 검사
+  validateBirthDate(birth: string): string | undefined {
+    const birthRegex = /^[0-9]{4}-?[0-9]{2}-?[0-9]{2}$/;
+    return validateRegex(birth.replace(/-/g, ""), birthRegex, ERROR_MESSAGES.BIRTH_DATE);
+  }
+
   // 전화번호 유효성 검사
   validatePhone(phone: string): string | undefined {
     const phoneRegex = /^01[016789]-?[0-9]{3,4}-?[0-9]{4}$/;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMeta {
     VITE_WEATHER_API_KEY: string;
     VITE_NAVER_API_ID_KEY: string;
     VITE_NAVER_SECRET_KEY: string;
+    VITE_NAVER_LOGIN_API_ID_KEY: string;
     VITE_KAKAO_API_KEY: string;
     VITE_GOOGLE_API_KEY: string;
     VITE_REDIRECT_URI: string;


### PR DESCRIPTION
- #143 

## 💡 변경사항 & 이슈
마이페이지 회원 정보 수정 구현
<br>

## ✍️ 관련 설명
회원 정보 수정 기능을 구현했습니다.

![image](https://github.com/user-attachments/assets/9869e43f-1bd9-4fde-b23a-00b8f84de559)
![image](https://github.com/user-attachments/assets/90236d3b-f7cf-45f7-bf31-44e0604afca5)

회원가입 시 이름, 닉네임, 전화번호, 생년월일을 유저의 full name에 문자열로 저장하도록 했습니다.

로그인한 후 context api를 활용해 유저 정보를 전역적으로 사용할 수 있도록 구현했습니다.
useAuth 훅을 활용해 유저 정보를 사용할 수 있습니다.
```
const { user } = useAuth();
```
- user: 유저 데이터
- login: 유저 데이터 저장
- logout: 유저 데이터 초기화
- updateUser: 유저 데이터 갱신
- modifyUser: 유저 데이터 수정

추가적인 기능은 필요할 때 추가할 예정입니다.
<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
