### PR TITLE
162 refactoring bookmark

### DIFF
--- a/src/components/mypage/BookmarkCard.tsx
+++ b/src/components/mypage/BookmarkCard.tsx
@@ -1,10 +1,12 @@
+import { MouseEvent } from "react";
+
 interface BookmarkCardProps {
   img: string;
   category: string;
   title: string;
   location: string;
   bookmarked: boolean;
-  handleClickBookmark: () => void;
+  handleClickBookmark: (e: MouseEvent<HTMLDivElement>) => void;
 }
 
 export default function BookmarkCard({
@@ -49,22 +51,23 @@ export default function BookmarkCard({
               <span className="text-[13px]">{location}</span>
             </div>
           </div>
-          <svg
-            width="30"
-            height="30"
-            viewBox="0 0 30 30"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            onClick={handleClickBookmark}
-          >
-            <circle cx="15" cy="15" r="15" fill="#D9D9D9" />
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M14.9999 8.38854C15.8749 7.49946 17.0144 7 18.2039 7C19.4884 7 20.7146 7.58238 21.6124 8.60881C22.5038 9.62713 23 10.9998 23 12.4254C23 13.851 22.5037 15.2238 21.6124 16.242C21.0197 16.9194 20.4279 17.6122 19.8331 18.3086C18.6249 19.723 17.4038 21.1526 16.1353 22.4995L16.1324 22.5026C15.4782 23.187 14.4422 23.1621 13.816 22.4465L8.38716 16.2419C6.53761 14.1281 6.53761 10.7227 8.38716 8.6089C10.1971 6.54038 13.1115 6.46693 14.9999 8.38854Z"
-              fill={bookmarked ? "#DC3644" : "#B4B4B4"}
-            />
-          </svg>
+          <div onClick={handleClickBookmark} className="cursor-pointer">
+            <svg
+              width="30"
+              height="30"
+              viewBox="0 0 30 30"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="15" cy="15" r="15" fill="#D9D9D9" />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M14.9999 8.38854C15.8749 7.49946 17.0144 7 18.2039 7C19.4884 7 20.7146 7.58238 21.6124 8.60881C22.5038 9.62713 23 10.9998 23 12.4254C23 13.851 22.5037 15.2238 21.6124 16.242C21.0197 16.9194 20.4279 17.6122 19.8331 18.3086C18.6249 19.723 17.4038 21.1526 16.1353 22.4995L16.1324 22.5026C15.4782 23.187 14.4422 23.1621 13.816 22.4465L8.38716 16.2419C6.53761 14.1281 6.53761 10.7227 8.38716 8.6089C10.1971 6.54038 13.1115 6.46693 14.9999 8.38854Z"
+                fill={bookmarked ? "#DC3644" : "#B4B4B4"}
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </article>

--- a/src/hooks/useAuth/AuthProvider.tsx
+++ b/src/hooks/useAuth/AuthProvider.tsx
@@ -6,15 +6,15 @@ import { UserInfoState } from "@pages/MypageInfo";
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const token = localStorage.getItem("token");
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
     if (!token) {
       logout();
     } else if (!user) {
       updateUser();
     }
-  }, [user]);
+  }, [user, token]);
 
   const login = (userData: User) => {
     localStorage.setItem("id", userData._id);
@@ -39,8 +39,6 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const modifyUser = async (userData: UserInfoState) => {
-    const token = localStorage.getItem("token");
-
     const response = await apiInstance.put<User>(
       "/settings/update-user",
       {
@@ -62,8 +60,6 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const updateUserImage = async (file: File) => {
-    const token = localStorage.getItem("token");
-
     const response = await apiInstance.post(
       "/users/upload-photo",
       {

--- a/src/hooks/useAuth/AuthProvider.tsx
+++ b/src/hooks/useAuth/AuthProvider.tsx
@@ -9,8 +9,9 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const token = localStorage.getItem("token");
-    if (token && !user) {
-      console.log(1);
+    if (!token) {
+      logout();
+    } else if (!user) {
       updateUser();
     }
   }, [user]);

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -66,9 +66,7 @@ export default function useBookMark(channelId: string) {
   };
 
   const updatePosts = async () => {
-    const data = (await apiInstance.get(`/posts/channel/${channelId}`)).data;
-
-    setPosts([...data]);
+    setPosts((await apiInstance.get(`/posts/channel/${channelId}`)).data);
     await updateUser();
   };
 

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -9,7 +9,6 @@ export default function useBookMark(channelId: string) {
 
   useEffect(() => {
     apiInstance.get<Post[]>(`/posts/channel/${channelId}`).then((res) => {
-      console.log(1, res.data);
       setPosts(res.data);
     });
   }, [channelId]);
@@ -35,7 +34,6 @@ export default function useBookMark(channelId: string) {
         },
         { headers: { Authorization: `Bearer ${token}` } },
       );
-      setPosts((await apiInstance.get(`/posts/channel/${channelId}`)).data);
     }
 
     const post = await apiInstance.get(`/search/all/${id}`);
@@ -47,7 +45,7 @@ export default function useBookMark(channelId: string) {
     );
 
     if (response.status === 200) {
-      await updateUser();
+      await updatePosts();
     }
   };
 
@@ -56,15 +54,22 @@ export default function useBookMark(channelId: string) {
 
     const token = localStorage.getItem("token");
     const likeId = user?.likes.find((like) => like.post === id);
-    console.log(likeId);
+
     const response = await apiInstance.delete("/likes/delete", {
       data: { id: likeId?._id },
       headers: { Authorization: `Bearer ${token}` },
     });
 
     if (response.status === 200) {
-      updateUser();
+      await updatePosts();
     }
+  };
+
+  const updatePosts = async () => {
+    const data = (await apiInstance.get(`/posts/channel/${channelId}`)).data;
+
+    setPosts([...data]);
+    await updateUser();
   };
 
   const isBookmarked = (id: string) => {

--- a/src/pages/Bookmark.tsx
+++ b/src/pages/Bookmark.tsx
@@ -2,7 +2,7 @@ import BookmarkCard from "@components/mypage/BookmarkCard";
 import useBookMark from "@hooks/useBookmark";
 
 export default function Bookmark() {
-  const { likes, posts } = useBookMark("67a0d8576e0e9a207c06c4ee");
+  const { likes, posts, handleUnlike } = useBookMark("67a0d8576e0e9a207c06c4ee");
 
   return (
     <div>
@@ -10,51 +10,21 @@ export default function Bookmark() {
       <div className="grid grid-cols-2 gap-x-11 gap-y-[30px]">
         {likes.map((like) => {
           const post = posts.find((p) => p._id === like.post);
+          const { title, category, image, location, id } = JSON.parse(post?.title || "{}");
           return (
             post && (
               <BookmarkCard
-                img={post.image || "https://placehold.co/450x250?text=CAMP+STORY"}
+                key={id}
+                img={image || "https://placehold.co/450x250?text=CAMP+STORY"}
                 bookmarked={true}
-                category="글램핑"
-                handleClickBookmark={() => alert("bookmark")}
-                location="전라도 담양군"
-                title="오스트리아캠핑"
+                category={category}
+                handleClickBookmark={(e) => handleUnlike(e, post._id)}
+                location={location}
+                title={title}
               />
             )
           );
         })}
-        <BookmarkCard
-          img="/images/camping/searchCamping.png"
-          bookmarked={true}
-          category="글램핑"
-          handleClickBookmark={() => alert("bookmark")}
-          location="전라도 담양군"
-          title="오스트리아캠핑"
-        />
-        <BookmarkCard
-          img="/images/camping/searchCamping.png"
-          bookmarked={true}
-          category="글램핑"
-          handleClickBookmark={() => alert("bookmark")}
-          location="전라도 담양군"
-          title="오스트리아캠핑"
-        />
-        <BookmarkCard
-          img="/images/camping/searchCamping.png"
-          bookmarked={true}
-          category="글램핑"
-          handleClickBookmark={() => alert("bookmark")}
-          location="전라도 담양군"
-          title="오스트리아캠핑"
-        />
-        <BookmarkCard
-          img="/images/camping/searchCamping.png"
-          bookmarked={true}
-          category="글램핑"
-          handleClickBookmark={() => alert("bookmark")}
-          location="전라도 담양군"
-          title="오스트리아캠핑"
-        />
       </div>
     </div>
   );

--- a/src/pages/Bookmark.tsx
+++ b/src/pages/Bookmark.tsx
@@ -1,10 +1,28 @@
 import BookmarkCard from "@components/mypage/BookmarkCard";
+import useBookMark from "@hooks/useBookmark";
 
 export default function Bookmark() {
+  const { likes, posts } = useBookMark("67a0d8576e0e9a207c06c4ee");
+
   return (
     <div>
       <div className="text-[26px] font-bold mb-8">찜 목록</div>
       <div className="grid grid-cols-2 gap-x-11 gap-y-[30px]">
+        {likes.map((like) => {
+          const post = posts.find((p) => p._id === like.post);
+          return (
+            post && (
+              <BookmarkCard
+                img={post.image || "https://placehold.co/450x250?text=CAMP+STORY"}
+                bookmarked={true}
+                category="글램핑"
+                handleClickBookmark={() => alert("bookmark")}
+                location="전라도 담양군"
+                title="오스트리아캠핑"
+              />
+            )
+          );
+        })}
         <BookmarkCard
           img="/images/camping/searchCamping.png"
           bookmarked={true}

--- a/src/pages/Bookmark.tsx
+++ b/src/pages/Bookmark.tsx
@@ -7,7 +7,7 @@ export default function Bookmark() {
   return (
     <div>
       <div className="text-[26px] font-bold mb-8">찜 목록</div>
-      <div className="grid grid-cols-2 gap-x-11 gap-y-[30px]">
+      <div className="grid grid-cols-2 gap-x-11 gap-y-[30px] mb-10">
         {likes.map((like) => {
           const post = posts.find((p) => p._id === like.post);
           const { title, category, image, location, id } = JSON.parse(post?.title || "{}");

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -216,7 +216,12 @@ export default function CampingSearch() {
                     handleClickBookmark={(e) =>
                       bookmarked
                         ? handleUnlike(e, bookmarked._id)
-                        : handleLike(e, item.contentId, item.firstImageUrl)
+                        : handleLike(e, item.contentId, {
+                            image: item.firstImageUrl,
+                            category: item.induty,
+                            location: item.addr1,
+                            title: item.facltNm,
+                          })
                     }
                     handleClick={() =>
                       navigate(PATH.campingInfo(item.contentId), { state: { item } })

--- a/src/pages/EventSearch.tsx
+++ b/src/pages/EventSearch.tsx
@@ -225,9 +225,7 @@ export default function EventSearch() {
                       navigate(PATH.eventInfo(event.contentid), { state: { event } })
                     }
                     handleClickBookmark={(e) =>
-                      bookmarked
-                        ? handleUnlike(e, bookmarked._id)
-                        : handleLike(e, event.contentid, event.firstimage)
+                      bookmarked ? handleUnlike(e, bookmarked._id) : handleLike(e, event.contentid)
                     }
                     location={`${event.addr1}`}
                     title={event.title}

--- a/src/pages/RestaurantSearch.tsx
+++ b/src/pages/RestaurantSearch.tsx
@@ -213,7 +213,7 @@ export default function RestaurantSearch() {
                     handleClickBookmark={(e) =>
                       bookmarked
                         ? handleUnlike(e, bookmarked._id)
-                        : handleLike(e, restaurant.contentid, restaurant.firstimage)
+                        : handleLike(e, restaurant.contentid)
                     }
                     location={`${restaurant.addr1}${restaurant.addr2 && `${restaurant.addr2}`}`}
                     title={restaurant.title}

--- a/src/types/ChannelResponse.ts
+++ b/src/types/ChannelResponse.ts
@@ -1,5 +1,16 @@
 import { Like, User } from "./AuthResponse";
 
+export interface PostOption {
+  title: string;
+  category: string;
+  location: string;
+  image: string;
+}
+
+export interface PostTitle extends Partial<PostOption> {
+  id: string;
+}
+
 export interface Channel {
   authRequired: boolean;
   posts: string[];


### PR DESCRIPTION
- #162 

## 💡 변경사항 & 이슈
찜하기 기능 구현
<br>

## ✍️ 관련 설명
찜하기 기능 구현을 진행했습니다.

### 캠핑, 행사, 음식점 찜하기
![image](https://github.com/user-attachments/assets/3c467307-041e-4660-a180-20d746ce1038)
![image](https://github.com/user-attachments/assets/8b7b5886-a10f-4f81-a05b-6297da8719fa)
![image](https://github.com/user-attachments/assets/fca5d125-78ed-433c-a60b-519bfa497d06)

### 마이페이지 찜 목록
![image](https://github.com/user-attachments/assets/a7920440-758e-4b12-b893-f140b7fe8857)

<br>

## ⭐️ Review point
마이페이지 찜목록에서 CampingDetail 페이지로 바로가기를 하고 싶었는데 구현을 미뤘습니다.
캠핑 데이터를 옵션으로 넘겨줘야 하는데 해당 데이터는 camping api를 통해서만 가져올 수 있어서 시간이 남을 때 CampingDetail 페이지에서 가져올 수 있도록 코드를 수정할까합니다.
<br>

## 📷 Demo

<br>
