### PR TITLE
167 filter questions by tags

### DIFF
--- a/src/pages/QuestionMain.tsx
+++ b/src/pages/QuestionMain.tsx
@@ -1,23 +1,25 @@
 import SearchInput from "@components/common/SearchInput";
 import OrderRadio from "@components/community/OrderRadio";
 import QuestionCard from "@components/community/question/QuestionCard";
-import QuestionTag from "@components/community/QuestionTag";
+import QuestionTag, { Tag } from "@components/community/QuestionTag";
 import { QUESTION_CHANNEL_ID } from "@constants/channelId";
 import { PATH } from "@constants/path";
 import PostResponse from "types/PostResponse";
 import { apiInstance } from "@utils/axiosInstance";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-// import PostResponse from "types/PostResponse";
+
+const TAGS: Tag[] = ["reservation", "payment", "member", "campingGear", "campsite", "tips"];
 
 export default function QuestionMain() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [keyword, setKeyword] = useState<string>();
   const [questionData, setQuestionData] = useState<PostResponse[]>([]);
   const [filteredData, setFilteredData] = useState<PostResponse[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [keyword, setKeyword] = useState<string>();
+  const [tagList, setTagList] = useState<string[]>([]);
 
   const handleSearch = (input: string) => {
     searchParams.set("keyword", input);
@@ -25,12 +27,34 @@ export default function QuestionMain() {
     setKeyword(input);
   };
 
-  const searchQuestionData = useCallback(
-    (input: string) => {
-      const data = questionData.filter((question) =>
-        JSON.parse(question.title).title.includes(input),
-      );
-      console.log("filteredData", data);
+  const handleCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const tags = [...tagList];
+    if (e.target.checked) {
+      console.log(e.target.value);
+      tags.push(e.target.value);
+    } else {
+      const index = tags.indexOf(e.target.value);
+      if (index !== -1) {
+        tags.splice(index, 1);
+      }
+    }
+    searchParams.set("tags", tags.join(","));
+    setSearchParams(searchParams);
+    setTagList(tags);
+  };
+
+  const filterQuestionData = useCallback(
+    (input: string | undefined, tags: string[]) => {
+      let data = questionData;
+      if (input) {
+        data = data.filter((question) => JSON.parse(question.title).title.includes(input));
+        console.log("filteredData", data);
+      }
+      if (tags.length !== 0) {
+        data = data.filter((question) =>
+          tags.some((tag) => JSON.parse(question.title).tag.includes(tag)),
+        );
+      }
       setFilteredData(data);
     },
     [questionData],
@@ -60,17 +84,16 @@ export default function QuestionMain() {
   }, []);
 
   useEffect(() => {
-    if (keyword) {
-      searchQuestionData(keyword);
+    if (keyword || tagList) {
+      filterQuestionData(keyword, tagList);
     }
-  }, [keyword, searchQuestionData]);
+  }, [keyword, filterQuestionData, tagList]);
 
   return (
     <div className="mt-14 px-4">
       {/* SearchBar */}
       <div className="mb-[60px]">
         <SearchInput handleSubmit={(input) => handleSearch(input)} />
-        {/* <SearchInput handleSubmit={(input) => <>{input}</>} /> */}
       </div>
 
       <div className="flex gap-[50px] justify-between items-center mb-[30px]">
@@ -82,12 +105,15 @@ export default function QuestionMain() {
 
         {/* Tags */}
         <div className="flex gap-3">
-          <QuestionTag tag="reservation" isCheckbox />
-          <QuestionTag tag="payment" isCheckbox />
-          <QuestionTag tag="member" isCheckbox />
-          <QuestionTag tag="campingGear" isCheckbox />
-          <QuestionTag tag="campsite" isCheckbox />
-          <QuestionTag tag="tips" isCheckbox />
+          {TAGS.map((tag) => (
+            <QuestionTag
+              tag={tag}
+              isCheckbox
+              handleChange={(e) => {
+                handleCheckbox(e);
+              }}
+            />
+          ))}
         </div>
 
         {/* Button */}
@@ -106,17 +132,13 @@ export default function QuestionMain() {
         {filteredData.map((question) => (
           <QuestionCard
             key={question._id}
-            handleClick={
-              () =>
-                navigate(PATH.questionPost(question._id), {
-                  state: { userId: question.author._id },
-                })
-              // navigate(PATH.questionPost(question._id), { state: { userId: question.author } })
+            handleClick={() =>
+              navigate(PATH.questionPost(question._id), {
+                state: { userId: question.author._id },
+              })
             }
             userName={JSON.parse(question.author.fullName).fullName}
-            // userName={"한라봉"}
             coverImage={question.author.image || "https://placehold.co/30x30?text=CAMP+STORY"}
-            // coverImage={"https://placehold.co/30x30?text=CAMP+STORY"}
             title={JSON.parse(question.title).title}
             timeStamp={new Date(question.createdAt).toLocaleDateString()}
           />

--- a/src/pages/QuestionMain.tsx
+++ b/src/pages/QuestionMain.tsx
@@ -18,8 +18,10 @@ export default function QuestionMain() {
   const [filteredData, setFilteredData] = useState<PostResponse[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [keyword, setKeyword] = useState<string>();
-  const [tagList, setTagList] = useState<string[]>([]);
+  const [keyword, setKeyword] = useState<string | null>(searchParams.get("keyword") || null);
+  const [tagList, setTagList] = useState<string[]>(
+    searchParams.get("tags") ? searchParams.get("tags")!.split(",") : [],
+  );
 
   const handleSearch = (input: string) => {
     setKeyword(input);
@@ -44,7 +46,7 @@ export default function QuestionMain() {
   };
 
   const filterQuestionData = useCallback(
-    (input: string | undefined, tags: string[]) => {
+    (input: string | null, tags: string[]) => {
       let data = questionData;
       if (input) {
         data = data.filter((question) => JSON.parse(question.title).title.includes(input));
@@ -107,6 +109,7 @@ export default function QuestionMain() {
               key={tag}
               tag={tag}
               isCheckbox
+              defaultChecked={tagList.includes(tag)}
               handleChange={(e) => {
                 handleCheckbox(e);
               }}

--- a/src/pages/QuestionMain.tsx
+++ b/src/pages/QuestionMain.tsx
@@ -22,9 +22,9 @@ export default function QuestionMain() {
   const [tagList, setTagList] = useState<string[]>([]);
 
   const handleSearch = (input: string) => {
+    setKeyword(input);
     searchParams.set("keyword", input);
     setSearchParams(searchParams);
-    setKeyword(input);
   };
 
   const handleCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -68,9 +68,6 @@ export default function QuestionMain() {
         `/posts/channel/${QUESTION_CHANNEL_ID}`,
       );
       setQuestionData(response.data);
-      setFilteredData(response.data);
-      console.log(response.data);
-      console.log(JSON.parse(response.data[0].title).title);
     } catch (error) {
       setError("질문 목록을 가져오는 중 오류가 발생했습니다.");
       console.log("Error fetching question data:", error);
@@ -107,6 +104,7 @@ export default function QuestionMain() {
         <div className="flex gap-3">
           {TAGS.map((tag) => (
             <QuestionTag
+              key={tag}
               tag={tag}
               isCheckbox
               handleChange={(e) => {

--- a/src/pages/QuestionMain.tsx
+++ b/src/pages/QuestionMain.tsx
@@ -4,16 +4,37 @@ import QuestionCard from "@components/community/question/QuestionCard";
 import QuestionTag from "@components/community/QuestionTag";
 import { QUESTION_CHANNEL_ID } from "@constants/channelId";
 import { PATH } from "@constants/path";
-import { apiInstance } from "@utils/axiosInstance";
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
 import PostResponse from "types/PostResponse";
+import { apiInstance } from "@utils/axiosInstance";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+// import PostResponse from "types/PostResponse";
 
 export default function QuestionMain() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [keyword, setKeyword] = useState<string>();
   const [questionData, setQuestionData] = useState<PostResponse[]>([]);
+  const [filteredData, setFilteredData] = useState<PostResponse[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = (input: string) => {
+    searchParams.set("keyword", input);
+    setSearchParams(searchParams);
+    setKeyword(input);
+  };
+
+  const searchQuestionData = useCallback(
+    (input: string) => {
+      const data = questionData.filter((question) =>
+        JSON.parse(question.title).title.includes(input),
+      );
+      console.log("filteredData", data);
+      setFilteredData(data);
+    },
+    [questionData],
+  );
 
   const fetchQuestionData = async () => {
     setIsLoading(true);
@@ -23,6 +44,7 @@ export default function QuestionMain() {
         `/posts/channel/${QUESTION_CHANNEL_ID}`,
       );
       setQuestionData(response.data);
+      setFilteredData(response.data);
       console.log(response.data);
       console.log(JSON.parse(response.data[0].title).title);
     } catch (error) {
@@ -36,11 +58,19 @@ export default function QuestionMain() {
   useEffect(() => {
     fetchQuestionData();
   }, []);
+
+  useEffect(() => {
+    if (keyword) {
+      searchQuestionData(keyword);
+    }
+  }, [keyword, searchQuestionData]);
+
   return (
     <div className="mt-14 px-4">
       {/* SearchBar */}
       <div className="mb-[60px]">
-        <SearchInput handleSubmit={() => alert("submit!")} />
+        <SearchInput handleSubmit={(input) => handleSearch(input)} />
+        {/* <SearchInput handleSubmit={(input) => <>{input}</>} /> */}
       </div>
 
       <div className="flex gap-[50px] justify-between items-center mb-[30px]">
@@ -73,14 +103,20 @@ export default function QuestionMain() {
       {isLoading && <p>로딩중...</p>}
       {error}
       <div className="grid grid-cols-2 gap-x-7 gap-y-10 justify-between">
-        {questionData.map((question) => (
+        {filteredData.map((question) => (
           <QuestionCard
             key={question._id}
-            handleClick={() =>
-              navigate(PATH.questionPost(question._id), { state: { userId: question.author._id } })
+            handleClick={
+              () =>
+                navigate(PATH.questionPost(question._id), {
+                  state: { userId: question.author._id },
+                })
+              // navigate(PATH.questionPost(question._id), { state: { userId: question.author } })
             }
             userName={JSON.parse(question.author.fullName).fullName}
+            // userName={"한라봉"}
             coverImage={question.author.image || "https://placehold.co/30x30?text=CAMP+STORY"}
+            // coverImage={"https://placehold.co/30x30?text=CAMP+STORY"}
             title={JSON.parse(question.title).title}
             timeStamp={new Date(question.createdAt).toLocaleDateString()}
           />


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#167 )

## 💡 변경사항 & 이슈
질문 페이지 검색 및 필터 기능 구현했습니다.
<br>

## ✍️ 관련 설명
검색 기능 구현할 때, 제공해주는 ```GET /search/all/{query}``` api를 활용해 검색 기능을 구현하려 했으나,
반환해주는 데이터에 author의 id만 있고, 나머지 정보(fullName, image)가 없었습니다.
이를 해결하기 위해 질문 채널의 모든 데이터를 불러온 후, 프론트에서 별도의 필터링 함수를 통해 구현해주었습니다.
<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
