### PR TITLE
178 add search and filter to communitypage

### DIFF
--- a/src/components/community/community/PostCard.tsx
+++ b/src/components/community/community/PostCard.tsx
@@ -19,6 +19,7 @@ interface PostCardProps {
   likeCount?: number;
   viewCount?: number;
   time: string;
+  userImage: string;
 }
 
 export default function PostCard({
@@ -28,6 +29,7 @@ export default function PostCard({
   img,
   time,
   tags,
+  userImage,
 }: PostCardProps) {
   const navigate = useNavigate();
   const handleClickCard = () => {
@@ -38,7 +40,7 @@ export default function PostCard({
   return (
     <div onClick={handleClickCard} className="cursor-pointer">
       <div className="flex flex-col gap-2.5 mb-[15px]">
-        <UserProfile nickname={fullname} profileUrl="" />
+        <UserProfile nickname={fullname} profileUrl={userImage || ""} />
 
         {/* TODO: || "https://placehold.co/490x320?text=CAMP+STORY" */}
         <div className="w-full h-[400px] overflow-hidden rounded-xl">

--- a/src/pages/CommunityMain.tsx
+++ b/src/pages/CommunityMain.tsx
@@ -13,6 +13,7 @@ interface Author {
   _id: string;
   fullName: string;
   email: string;
+  image: string;
 }
 
 interface Post {
@@ -176,6 +177,7 @@ export default function CommunityMain() {
               img={post.image}
               tags={JSON.parse(post.title).tags}
               time={getRelativeTime(post.createdAt)}
+              userImage={post.author.image}
             />
           );
         })}

--- a/src/pages/CommunityMain.tsx
+++ b/src/pages/CommunityMain.tsx
@@ -3,8 +3,8 @@ import OrderRadio from "@components/community/OrderRadio";
 import PostCard from "@components/community/community/PostCard";
 import Tag from "@components/community/Tag";
 import { PATH } from "@constants/path";
-import { useNavigate } from "react-router";
-import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { useCallback, useEffect, useState } from "react";
 import { apiInstance } from "@utils/axiosInstance";
 import getRelativeTime from "@utils/getRelativeTime";
 import { COMMUNITY_CHANNEL_ID } from "@constants/channelId";
@@ -25,11 +25,62 @@ interface Post {
   author: Author;
 }
 
+const KEYWORD_PARAM = "keyword";
+const TAG_PARAM = "tag";
+
 export default function CommunityMain() {
   const navigate = useNavigate();
-
+  const [searchParams, setSearchParams] = useSearchParams();
   const [posts, setPosts] = useState<Post[]>([]);
+  const [filteredPosts, setFilteredPosts] = useState<Post[]>([]);
   const [sortOrder, setSortOrder] = useState<"recent" | "popular">("recent");
+  const keyword = searchParams.get(KEYWORD_PARAM) || null;
+  const [tagList, setTagList] = useState<string[]>(
+    searchParams.get("tags") ? searchParams.get("tags")!.split(",") : [],
+  );
+
+  const updateSearchParams = useCallback(
+    (key: string, value: string) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set(key, value);
+      setSearchParams(newParams);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleTagChange = (tag: string, checked: boolean) => {
+    const tags = [...tagList];
+    if (checked) tags.push(tag);
+    else {
+      const index = tagList.indexOf(tag);
+      if (index !== -1) {
+        tags.splice(index, 1);
+      }
+    }
+    updateSearchParams(TAG_PARAM, tags.join(","));
+    setTagList(tags);
+  };
+
+  const handleSearch = useCallback(
+    (searchKeyword: string) => {
+      updateSearchParams(KEYWORD_PARAM, searchKeyword);
+    },
+    [updateSearchParams],
+  );
+
+  const filterPostList = useCallback(
+    (input: string | null, tags: string[]) => {
+      let data = posts;
+      if (input) {
+        data = data.filter((post) => JSON.parse(post.title).content.includes(input));
+      }
+      if (tags.length !== 0) {
+        data = data.filter((post) => tags.some((tag) => JSON.parse(post.title).tags.includes(tag)));
+      }
+      setFilteredPosts(data);
+    },
+    [posts],
+  );
 
   useEffect(() => {
     apiInstance
@@ -37,13 +88,20 @@ export default function CommunityMain() {
       .then((res) => {
         const validPosts = res.data.filter((post) => post.author);
         setPosts(validPosts);
+        setFilteredPosts(validPosts);
       })
       .catch((err) => {
         console.error("게시글 불러오기 실패:", err);
       });
   }, []);
 
-  const sortedPosts = [...posts].sort((a, b) => {
+  useEffect(() => {
+    if (keyword || tagList) {
+      filterPostList(keyword, tagList);
+    }
+  }, [keyword, filterPostList, tagList]);
+
+  const sortedPosts = [...filteredPosts].sort((a, b) => {
     if (sortOrder === "recent") {
       // 최신순: 생성시간 내림차순 (최근 것이 먼저)
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -57,7 +115,7 @@ export default function CommunityMain() {
   return (
     <>
       <div className="mt-14 mb-[60px]">
-        <SearchInput handleSubmit={() => alert("submit!")} />
+        <SearchInput handleSubmit={(input) => handleSearch(input)} />
       </div>
 
       <div className="flex gap-[50px] justify-between items-center mb-[30px]">
@@ -72,9 +130,24 @@ export default function CommunityMain() {
         </div>
 
         <div className="flex gap-[5px]">
-          <Tag tag="clean" isCheckbox />
-          <Tag tag="kind" isCheckbox />
-          <Tag tag="convenience" isCheckbox />
+          <Tag
+            tag="clean"
+            isCheckbox
+            defaultChecked={tagList.includes("clean")}
+            onChange={(checked: boolean) => handleTagChange("clean", checked)}
+          />
+          <Tag
+            tag="kind"
+            isCheckbox
+            defaultChecked={tagList.includes("kind")}
+            onChange={(checked: boolean) => handleTagChange("kind", checked)}
+          />
+          <Tag
+            tag="convenience"
+            isCheckbox
+            defaultChecked={tagList.includes("convenience")}
+            onChange={(checked: boolean) => handleTagChange("convenience", checked)}
+          />
         </div>
 
         <button


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#178 )

## 💡 변경사항 & 이슈
커뮤니티 페이지 검색 및 필터 기능 구현 했습니다.
유저 이미지 추가 해주었습니다.
<br>

## ✍️ 관련 설명
### 검색
  - 본문 내용으로 검색할 수 있게 구현했습니다.
![스크린샷 2025-02-05 오후 1 00 25](https://github.com/user-attachments/assets/48b4e5d9-a5db-4013-a9b9-3c451e7ec206)

### 필터
  - 태그에 따라서 포스트가 필터링 되게 구현했습니다. 
![스크린샷 2025-02-05 오후 1 01 42](https://github.com/user-attachments/assets/040e747a-c340-4f43-91ca-3ac48c7210fb)

### 유저 이미지 추가
  - 기존에 보이지 않던 유저 이미지를 추가해주었습니다.
<br>
## ⭐️ Review point

<br>

## 📷 Demo

<br>
