### PR TITLE
193 redesign restaurant categorycard

### DIFF
--- a/src/components/food/RestaurantMain/CategoryCard.tsx
+++ b/src/components/food/RestaurantMain/CategoryCard.tsx
@@ -9,14 +9,14 @@ export default function CategoryCard({ src, catName, onClick }: CategoryCardProp
     <>
       <button
         onClick={onClick}
-        className="flex flex-col items-center justify-center h-[196px] mt-7 bg-white shadow-md rounded-lg hover:brightness-75 transition"
+        className="flex flex-col items-center justify-center py-[40px] px-[30px] bg-white drop-shadow-custom rounded-xl hover:shadow-lg transition"
       >
         <div className="w-15 bg-gray-200 rounded-full">
           {/* 아이콘/이미지 */}
           <img src={src} alt="flags" className="m-3" />
         </div>
         {/* 카테고리 이름 */}
-        <span className="text-[20px] font-semibold mt-3">{catName}</span>
+        <span className="text-sub-title text-gray-scale-400 font-semibold mt-3">{catName}</span>
       </button>
     </>
   );

--- a/src/components/food/RestaurantMain/Title.tsx
+++ b/src/components/food/RestaurantMain/Title.tsx
@@ -9,7 +9,10 @@ export default function Subtitle({ title, summary }: SubtitleProps) {
   return (
     <div className="text-left">
       {titleLines.map((line, index) => (
-        <div key={index} className="text-highlight font-impact leading-tight mb-2">
+        <div
+          key={index}
+          className="text-gray-scale-400 text-highlight font-impact leading-tight mb-2"
+        >
           {line}
         </div>
       ))}

--- a/src/components/food/RestaurantMain/TodaysPick.tsx
+++ b/src/components/food/RestaurantMain/TodaysPick.tsx
@@ -13,7 +13,9 @@ export default function TodaysPick({ src, title, summary, path }: TodaysPickProp
   return (
     <div className="rounded-lg hover:brightness-75" onClick={() => navigate(path)}>
       <img src={src} alt="tofu-restaurant" />
-      <span className="text-[26px] font-bold text-left inline-block mt-[12px]">{title}</span>
+      <span className="text-[26px] text-gray-scale-400 font-bold text-left inline-block mt-[12px]">
+        {title}
+      </span>
       <p className="text-gray-scale-200 text-[15px]">{summary}</p>
     </div>
   );

--- a/src/pages/RestaurantMain.tsx
+++ b/src/pages/RestaurantMain.tsx
@@ -53,7 +53,7 @@ function MainPage() {
     <div className="flex flex-col gap-[100px]">
       <Banner />
 
-      <section>
+      <section className="flex flex-col gap-8">
         {/* 상단 제목 */}
         <div>
           <Title
@@ -63,7 +63,7 @@ function MainPage() {
         </div>
 
         {/* 카테고리 카드들 */}
-        <div className="grid grid-cols-6 gap-4">
+        <div className="grid grid-cols-6 gap-6">
           {categories.map((category) => (
             <CategoryCard
               src={category.image}


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#193 )

## 💡 변경사항 & 이슈
음식 페이지의 카테고리 카드 디자인 다듬고, 글자 색 수정해주었습니다.
<br>

## ✍️ 관련 설명
### 📌 Before

![스크린샷 2025-02-05 오후 4 49 45](https://github.com/user-attachments/assets/63a0b741-2496-4a2f-8eea-04cd16bc831b)

### 📌 After

![스크린샷 2025-02-05 오후 4 50 13](https://github.com/user-attachments/assets/04c3994b-37b9-47ea-8272-5b7774e7410c)

<br>
## ⭐️ Review point

<br>

## 📷 Demo

<br>
