### PR TITLE
188 redesign swiper arrow

### DIFF
--- a/public/images/arrow-left.svg
+++ b/public/images/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.625 18.75L9.375 12.5L15.625 6.25" stroke="#333333" stroke-width="1.14583" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/arrow-right.svg
+++ b/public/images/arrow-right.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame">
+<path id="Vector" d="M9.375 6.25L15.625 12.5L9.375 18.75" stroke="#333333" stroke-width="1.14583" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/common/SwiperArrow.tsx
+++ b/src/components/common/SwiperArrow.tsx
@@ -1,0 +1,34 @@
+import { twMerge } from "tailwind-merge";
+
+interface SwiperArrowProps {
+  isEnd: boolean;
+  isBeginning: boolean;
+  handleNext: () => void;
+  handlePrev: () => void;
+}
+
+export default function SwiperArrow({
+  handleNext,
+  handlePrev,
+  isBeginning,
+  isEnd,
+}: SwiperArrowProps) {
+  const className =
+    "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 z-50";
+  return (
+    <>
+      <div
+        className={twMerge(className, "-left-[22px]", isBeginning ? "hidden" : "visible")}
+        onClick={handlePrev}
+      >
+        <img src="/images/arrow-left.svg" />
+      </div>
+      <div
+        className={twMerge(className, "-right-[22px]", isEnd ? "hidden" : "visible")}
+        onClick={handleNext}
+      >
+        <img src="/images/arrow-right.svg" />
+      </div>
+    </>
+  );
+}

--- a/src/components/common/SwiperArrow.tsx
+++ b/src/components/common/SwiperArrow.tsx
@@ -3,6 +3,7 @@ import { twMerge } from "tailwind-merge";
 interface SwiperArrowProps {
   isEnd: boolean;
   isBeginning: boolean;
+  top: "sm" | "lg";
   handleNext: () => void;
   handlePrev: () => void;
 }
@@ -12,19 +13,35 @@ export default function SwiperArrow({
   handlePrev,
   isBeginning,
   isEnd,
+  top,
 }: SwiperArrowProps) {
   const className =
-    "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 z-50";
+    "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute -translate-y-1/2 z-50";
+
+  const topClassName = {
+    sm: "top-[112px]",
+    lg: "top-[150px]",
+  };
   return (
     <>
       <div
-        className={twMerge(className, "-left-[22px]", isBeginning ? "hidden" : "visible")}
+        className={twMerge(
+          className,
+          topClassName[top],
+          "-left-[22px]",
+          isBeginning ? "hidden" : "visible",
+        )}
         onClick={handlePrev}
       >
         <img src="/images/arrow-left.svg" />
       </div>
       <div
-        className={twMerge(className, "-right-[22px]", isEnd ? "hidden" : "visible")}
+        className={twMerge(
+          className,
+          topClassName[top],
+          "-right-[22px]",
+          isEnd ? "hidden" : "visible",
+        )}
         onClick={handleNext}
       >
         <img src="/images/arrow-right.svg" />

--- a/src/components/home/TopCampingSpotsSection.tsx
+++ b/src/components/home/TopCampingSpotsSection.tsx
@@ -5,6 +5,8 @@ import CampingSpotItemType from "../../types/CampingSpotItemType";
 import { PATH } from "@constants/path";
 import PopularCampCardProps from "types/PopularCampingCardProps";
 import useCamping from "@hooks/useCamping";
+import SwiperArrow from "@components/common/SwiperArrow";
+import useSwiper from "@hooks/useSwiper";
 
 const PopularCampingData: PopularCampCardProps[] = [
   {
@@ -84,30 +86,42 @@ function CampingSpotItem({ path, src, name, category }: CampingSpotItemType) {
 }
 
 export default function TopCampingSpotsSection() {
+  const { handleSlideChange, handleNext, handlePrev, isBeginning, isEnd, swiperRef } = useSwiper();
+
   return (
     <section className="mb-7 relative">
       <h2 className="text-highlight font-impact">인기 캠핑장</h2>
       <p className="text-sub-title text-gray-scale-300 mb-7">
         나를 위한 근사한 휴가를 계획해보세요.
       </p>
-      <Swiper
-        modules={[Navigation, Pagination, A11y]}
-        spaceBetween={32}
-        slidesPerView={5}
-        navigation
-        pagination={{ clickable: true }}
-      >
-        {PopularCampingData.map((item) => (
-          <SwiperSlide key={item.src}>
-            <CampingSpotItem
-              path={item.path}
-              src={item.src}
-              name={item.name}
-              category={item.category}
-            />
-          </SwiperSlide>
-        ))}
-      </Swiper>
+      <div className="relative overflow-visible">
+        <SwiperArrow
+          handleNext={handleNext}
+          handlePrev={handlePrev}
+          isBeginning={isBeginning}
+          isEnd={isEnd}
+          top="sm"
+        />
+        <Swiper
+          modules={[Navigation, Pagination, A11y]}
+          spaceBetween={32}
+          slidesPerView={5}
+          pagination={{ clickable: true }}
+          onSwiper={(swiper) => (swiperRef.current = swiper)}
+          onSlideChange={handleSlideChange}
+        >
+          {PopularCampingData.map((item) => (
+            <SwiperSlide key={item.src}>
+              <CampingSpotItem
+                path={item.path}
+                src={item.src}
+                name={item.name}
+                category={item.category}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
       <Link to={PATH.campingSearch} className="absolute top-5 font-bold right-0 text-info-500">
         더보기
       </Link>

--- a/src/components/layouts/RootLayout.tsx
+++ b/src/components/layouts/RootLayout.tsx
@@ -4,6 +4,7 @@ import "swiper/css";
 import { useEffect } from "react";
 import { getTokenDuration } from "@utils/authToken";
 import AuthProvider from "@hooks/useAuth/AuthProvider";
+import ScrollToTop from "./ScrollToTop";
 
 export default function RootLayout() {
   const token = useLoaderData();
@@ -33,6 +34,7 @@ export default function RootLayout() {
           <header className="sticky top-0 bg-gray-scale-0 py-3 z-20">
             <MainNavigation token={token} />
           </header>
+          <ScrollToTop />
           <Outlet />
         </div>
       </div>

--- a/src/components/layouts/ScrollToTop.tsx
+++ b/src/components/layouts/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0); // 페이지 변경 시 스크롤 최상단 이동
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/hooks/useSwiper.tsx
+++ b/src/hooks/useSwiper.tsx
@@ -1,0 +1,27 @@
+import { useRef, useState } from "react";
+import { Swiper as SwiperType } from "swiper/types";
+
+export default function useSwiper() {
+  const swiperRef = useRef<SwiperType | null>(null);
+
+  const [isBeginning, setIsBeginning] = useState(true);
+  const [isEnd, setIsEnd] = useState(false);
+
+  const handleSlideChange = (swiper: SwiperType) => {
+    setIsBeginning(swiper.isBeginning);
+    setIsEnd(swiper.isEnd);
+  };
+
+  const handleNext = () => swiperRef.current?.slideNext();
+
+  const handlePrev = () => swiperRef.current?.slidePrev();
+
+  return {
+    swiperRef,
+    isBeginning,
+    isEnd,
+    handleSlideChange,
+    handleNext,
+    handlePrev,
+  };
+}

--- a/src/pages/CampingMain.tsx
+++ b/src/pages/CampingMain.tsx
@@ -157,6 +157,7 @@ export default function CampingMain() {
             handlePrev={handlePrev}
             isBeginning={isBeginning}
             isEnd={isEnd}
+            top="lg"
           />
           <Swiper
             style={{ width: "100%", height: "auto" }}

--- a/src/pages/CampingMain.tsx
+++ b/src/pages/CampingMain.tsx
@@ -11,11 +11,10 @@ import { useNavigate } from "react-router";
 // Swiper 관련 모듈
 import { Navigation, A11y, Autoplay } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Swiper as SwiperType } from "swiper/types";
 import "swiper/css";
 import "swiper/css/navigation";
-import { useRef, useState } from "react";
-import { twMerge } from "tailwind-merge";
+import useSwiper from "@hooks/useSwiper";
+import SwiperArrow from "@components/common/SwiperArrow";
 // import "swiper/css/pagination";
 
 const PopularCampingData: PopularCampCardProps[] = [
@@ -111,15 +110,7 @@ const ReviewData: ReviewCardProps[] = [
 
 export default function CampingMain() {
   const navigate = useNavigate();
-  const swiperRef = useRef<SwiperType | null>(null);
-
-  const [isBeginning, setIsBeginning] = useState(true); // 첫 번째 슬라이드 여부
-  const [isEnd, setIsEnd] = useState(false); // 마지막 슬라이드 여부
-
-  const handleSlideChange = (swiper: SwiperType) => {
-    setIsBeginning(swiper.isBeginning); // 첫 번째 슬라이드인지 확인
-    setIsEnd(swiper.isEnd); // 마지막 슬라이드인지 확인
-  };
+  const { handleSlideChange, handleNext, handlePrev, isBeginning, isEnd, swiperRef } = useSwiper();
 
   return (
     <div className="flex flex-col gap-[60px]">
@@ -161,46 +152,32 @@ export default function CampingMain() {
       <div>
         <Subtitle>인기 캠핑장</Subtitle>
         <div className="relative overflow-visible">
-          <div
-            className={twMerge(
-              "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 -right-[22px] z-50",
-              isEnd ? "hidden" : "visible",
-            )}
-            onClick={() => swiperRef.current?.slideNext()}
+          <SwiperArrow
+            handleNext={handleNext}
+            handlePrev={handlePrev}
+            isBeginning={isBeginning}
+            isEnd={isEnd}
+          />
+          <Swiper
+            style={{ width: "100%", height: "auto" }}
+            modules={[Navigation, A11y, Autoplay]}
+            spaceBetween={10}
+            slidesPerView={4}
+            onSwiper={(swiper) => (swiperRef.current = swiper)}
+            onSlideChange={handleSlideChange}
           >
-            <img src="/images/arrow-right.svg" />
-          </div>
-          <div
-            className={twMerge(
-              "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 -left-[22px] z-50",
-              isBeginning ? "hidden" : "visible",
-            )}
-            onClick={() => swiperRef.current?.slidePrev()}
-          >
-            <img src="/images/arrow-left.svg" />
-          </div>
-          <div>
-            <Swiper
-              style={{ width: "100%", height: "auto" }}
-              modules={[Navigation, A11y, Autoplay]}
-              spaceBetween={10}
-              slidesPerView={4}
-              onSwiper={(swiper) => (swiperRef.current = swiper)}
-              onSlideChange={handleSlideChange}
-            >
-              {PopularCampingData.map((item: PopularCampCardProps, idx: number) => (
-                <SwiperSlide key={idx}>
-                  <PopularCampCard
-                    rank={item.rank}
-                    src={item.src}
-                    category={item.category}
-                    name={item.name}
-                    path={item.path}
-                  />
-                </SwiperSlide>
-              ))}
-            </Swiper>
-          </div>
+            {PopularCampingData.map((item: PopularCampCardProps, idx: number) => (
+              <SwiperSlide key={idx}>
+                <PopularCampCard
+                  rank={item.rank}
+                  src={item.src}
+                  category={item.category}
+                  name={item.name}
+                  path={item.path}
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
         </div>
       </div>
       <div>

--- a/src/pages/CampingMain.tsx
+++ b/src/pages/CampingMain.tsx
@@ -11,8 +11,11 @@ import { useNavigate } from "react-router";
 // Swiper 관련 모듈
 import { Navigation, A11y, Autoplay } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
+import { Swiper as SwiperType } from "swiper/types";
 import "swiper/css";
 import "swiper/css/navigation";
+import { useRef, useState } from "react";
+import { twMerge } from "tailwind-merge";
 // import "swiper/css/pagination";
 
 const PopularCampingData: PopularCampCardProps[] = [
@@ -108,6 +111,15 @@ const ReviewData: ReviewCardProps[] = [
 
 export default function CampingMain() {
   const navigate = useNavigate();
+  const swiperRef = useRef<SwiperType | null>(null);
+
+  const [isBeginning, setIsBeginning] = useState(true); // 첫 번째 슬라이드 여부
+  const [isEnd, setIsEnd] = useState(false); // 마지막 슬라이드 여부
+
+  const handleSlideChange = (swiper: SwiperType) => {
+    setIsBeginning(swiper.isBeginning); // 첫 번째 슬라이드인지 확인
+    setIsEnd(swiper.isEnd); // 마지막 슬라이드인지 확인
+  };
 
   return (
     <div className="flex flex-col gap-[60px]">
@@ -148,27 +160,48 @@ export default function CampingMain() {
       </div>
       <div>
         <Subtitle>인기 캠핑장</Subtitle>
-        <Swiper
-          style={{ width: "100%", height: "auto" }}
-          modules={[Navigation, A11y, Autoplay]}
-          spaceBetween={10}
-          slidesPerView={4}
-          navigation
-          // pagination={{ clickable: true }}
-          // autoplay={{ delay: 2500 }}
-        >
-          {PopularCampingData.map((item: PopularCampCardProps, idx: number) => (
-            <SwiperSlide key={idx}>
-              <PopularCampCard
-                rank={item.rank}
-                src={item.src}
-                category={item.category}
-                name={item.name}
-                path={item.path}
-              />
-            </SwiperSlide>
-          ))}
-        </Swiper>
+        <div className="relative overflow-visible">
+          <div
+            className={twMerge(
+              "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 -right-[22px] z-50",
+              isEnd ? "hidden" : "visible",
+            )}
+            onClick={() => swiperRef.current?.slideNext()}
+          >
+            <img src="/images/arrow-right.svg" />
+          </div>
+          <div
+            className={twMerge(
+              "p-[14px] size-[53px] rounded-full bg-white drop-shadow-custom absolute top-[150px] -translate-y-1/2 -left-[22px] z-50",
+              isBeginning ? "hidden" : "visible",
+            )}
+            onClick={() => swiperRef.current?.slidePrev()}
+          >
+            <img src="/images/arrow-left.svg" />
+          </div>
+          <div>
+            <Swiper
+              style={{ width: "100%", height: "auto" }}
+              modules={[Navigation, A11y, Autoplay]}
+              spaceBetween={10}
+              slidesPerView={4}
+              onSwiper={(swiper) => (swiperRef.current = swiper)}
+              onSlideChange={handleSlideChange}
+            >
+              {PopularCampingData.map((item: PopularCampCardProps, idx: number) => (
+                <SwiperSlide key={idx}>
+                  <PopularCampCard
+                    rank={item.rank}
+                    src={item.src}
+                    category={item.category}
+                    name={item.name}
+                    path={item.path}
+                  />
+                </SwiperSlide>
+              ))}
+            </Swiper>
+          </div>
+        </div>
       </div>
       <div>
         <Subtitle>지역별 캠핑장</Subtitle>


### PR DESCRIPTION
- #188 

## 💡 변경사항 & 이슈
스와이퍼의 화살표 디자인을 수정했습니다.
<br>

## ✍️ 관련 설명
### 보이는 아이템에 따라 arrow 숨기기
![image](https://github.com/user-attachments/assets/ac5dc89d-8f32-4bb7-8919-280852d0ff72)
![image](https://github.com/user-attachments/assets/28811881-cf48-4b47-9fda-2bdc7919b527)
![image](https://github.com/user-attachments/assets/99104540-ca41-425b-a498-e4b412bb542b)

### 캠핑과 메인 페이지 모두 적용
![image](https://github.com/user-attachments/assets/93f9fdf0-d9d3-4f56-a984-d91643d422cb)

### scroll to top
페이지 이동할 때 스크롤 위치가 고정되는 점이 불편하게 느껴져서 항상 페이지의 최상단으로 이동할 수 있도록 변경했습니다.
<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
