### PR TITLE
197 fix mypage activities question

### DIFF
--- a/src/components/event/Banner.tsx
+++ b/src/components/event/Banner.tsx
@@ -2,7 +2,7 @@ import SearchBar from "./SearchBar";
 
 export default function Banner() {
   return (
-    <div className="relative mt-[10px]">
+    <div className="relative">
       <img
         src="/images/festival/festival-banner.png"
         alt="festival banner"

--- a/src/components/food/RestaurantMain/Banner.tsx
+++ b/src/components/food/RestaurantMain/Banner.tsx
@@ -2,7 +2,7 @@ import SearchBar from "./SearchBar";
 
 export default function Banner() {
   return (
-    <div className="relative mt-[10px]">
+    <div className="relative">
       <img src="/images/food/food-banner.png" alt="메인이미지" className="w-full object-cover" />
       <SearchBar className="absolute bottom-[60px] left-[50%] -translate-x-[50%]" />
     </div>

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -138,7 +138,7 @@ export const AREA = [
 
 export const CAMPING_AREA = [
   {
-    value: "서울시",
+    value: "서울",
     label: "서울",
   },
   {
@@ -150,7 +150,7 @@ export const CAMPING_AREA = [
     label: "강원도",
   },
   {
-    value: "부산시",
+    value: "부산",
     label: "부산",
   },
   {

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -16,7 +16,7 @@ export default function useInfiniteScroll({
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && !isLoading && !isPageEnd) {
-          console.log("화면 끝!", entries[0]);
+          // console.log("화면 끝!", entries[0]);
           setPageNumber((prev) => prev + 1);
         }
       },

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+
+interface useInfiniteScrollProps {
+  isLoading: boolean;
+  isPageEnd: boolean;
+  setPageNumber: (updater: (prev: number) => number) => void;
+}
+
+export default function useInfiniteScroll({
+  isLoading,
+  isPageEnd,
+  setPageNumber,
+}: useInfiniteScrollProps) {
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoading && !isPageEnd) {
+          console.log("화면 끝!", entries[0]);
+          setPageNumber((prev) => prev + 1);
+        }
+      },
+      { threshold: 0 },
+    );
+    const currentRef = loadMoreRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [isLoading, isPageEnd, setPageNumber]);
+  return { loadMoreRef };
+}

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -90,6 +90,7 @@ export default function CampingSearch() {
   const handleSearch = (searchKeyword: string) => {
     setPageNumber(1);
     setCampingData([]);
+    setIsPageEnd(false);
     searchParams.set("keyword", searchKeyword);
     setSearchParams(searchParams);
     setKeyword(searchKeyword);
@@ -99,13 +100,12 @@ export default function CampingSearch() {
   const handleCheckbox = (criteria: "category" | "area", value: string, isChecked: boolean) => {
     const queryList = criteria === "category" ? [...categoryFilterList] : [...areaFilterList];
     const setFunc = criteria === "category" ? setCategoryFilterList : setAreaFilterList;
+    setPageNumber(1);
+    setIsPageEnd(false);
+    setCampingData([]);
     if (isChecked) {
-      setPageNumber(1);
-      setCampingData([]);
       queryList.push(value);
     } else {
-      setPageNumber(1);
-      setCampingData([]);
       const index = queryList.indexOf(value);
       if (index !== -1) {
         queryList.splice(index, 1);

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -13,7 +13,7 @@ import useBookMark from "@hooks/useBookmark";
 import { CAMPING_CHANNEL_ID } from "@constants/channelId";
 import useInfiniteScroll from "@hooks/useInfiniteScroll";
 
-const NUM_OF_ROWS = 300;
+const NUM_OF_ROWS = 50;
 
 export default function CampingSearch() {
   const navigate = useNavigate();
@@ -191,7 +191,7 @@ export default function CampingSearch() {
             {keyword ? `' ${keyword} '` : "전체"} 검색 결과{" "}
             {Intl.NumberFormat("ko-KR").format(Number(campingData.length))}개
           </h2>
-          {isLoading && "로딩중.."}
+          {/* {isLoading && "로딩중.."} */}
           <div className="grid grid-cols-2 gap-x-5 gap-y-[30px]">
             {campingData.length !== 0 ? (
               campingData.map((item) => {
@@ -226,7 +226,7 @@ export default function CampingSearch() {
               </>
             )}
           </div>
-          <div ref={loadMoreRef} className="bg-slate-100 h-40" />
+          <div ref={loadMoreRef} className="h-40" />
         </div>
       </div>
     </>

--- a/src/pages/MypageActivities.tsx
+++ b/src/pages/MypageActivities.tsx
@@ -35,7 +35,7 @@ export default function MypageActivities() {
     fetchPostData();
   }, [fetchPostData]);
   return (
-    <div className="max-w-[880px] mb-[100px]">
+    <div className="w-[880px] mb-[100px]">
       {isLoading && <p>로딩중...</p>}
       {error}
       <h2 className="text-title font-bold">나의 활동</h2>


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#197 )

## 💡 변경사항 & 이슈
- 마이페이지 질문 컴포넌트 크기 달라지는 이슈 수정했습니다.
- 무한스크롤 커스텀 훅으로 분리 및 기능 보완 했습니다.
<br>

## ✍️ 관련 설명

### 1. 마이페이지 질문 컴포넌트
아래 사진과 같은 문제가 있었는데, 상위 요소에 width 를 주어 수정했습니다.
![스크린샷 2025-02-05오후 5 33 06](https://github.com/user-attachments/assets/64480bc4-c341-4d6a-b3ae-6e89c6130766)
### 2. 무한스크롤
- 커스텀 훅으로 분리하여 캠핑, 행사, 음식점 페이지에 적용해주었습니다.
- 페이지가 끝났음에도 계속 로딩되는 문제
: ```isPageEnd``` 상태 관리를 통해서 마지막 페이지일 경우 데이터를 그만 불러오도록 하여 해결했습니다. 
- 행사 페이지와 음식점 페이지는 새 페이지 데이터가 로딩될 때 전체 데이터가 리렌더 되는 문제를 해결하지 못한 상태입니다.

<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
