### PR TITLE
206 add navigation to nearby attraction

### DIFF
--- a/src/components/detail/NearbyPlaceItem.tsx
+++ b/src/components/detail/NearbyPlaceItem.tsx
@@ -1,4 +1,12 @@
+import { PATH } from "@constants/path";
 import useBookMark from "@hooks/useBookmark";
+import { campingDataResponse } from "types/CampingDataResponse";
+import { useNavigate } from "react-router";
+import { CommonDetails } from "types/EventResponse";
+import { NearbyRestaurantResponse } from "types/RestaurantResponse";
+
+// 유니온 타입 정의
+type PlaceData = campingDataResponse | CommonDetails | NearbyRestaurantResponse;
 
 interface NearbyPlaceItemProps {
   imageUrl: string;
@@ -7,9 +15,22 @@ interface NearbyPlaceItemProps {
   channelId: string;
   contentId: string;
   location: string;
+  data: PlaceData;
 }
 
+// 타입 가드 함수들
+const isCampingData = (place: PlaceData): place is campingDataResponse => {
+  return (place as campingDataResponse).facltNm !== undefined;
+};
+const isEventData = (place: PlaceData): place is CommonDetails => {
+  return (place as CommonDetails).contenttypeid !== undefined && !(place as CommonDetails).zipcode;
+};
+const isRestaurantData = (place: PlaceData): place is NearbyRestaurantResponse => {
+  return (place as NearbyRestaurantResponse).zipcode !== undefined;
+};
+
 export default function NearbyPlaceItem({
+  data,
   imageUrl,
   category,
   name,
@@ -18,12 +39,24 @@ export default function NearbyPlaceItem({
   location,
 }: NearbyPlaceItemProps) {
   const { isBookmarked, handleUnlike, handleLike } = useBookMark(channelId);
-
+  const navigate = useNavigate();
   const bookmarked = isBookmarked(contentId);
+  const handleClick = () => {
+    if (isCampingData(data)) {
+      navigate(PATH.campingInfo(contentId), { state: { item: data } });
+    } else if (isEventData(data)) {
+      navigate(PATH.eventInfo(contentId), { state: { event: data } });
+    } else if (isRestaurantData(data)) {
+      navigate(PATH.restaurantInfo(contentId), { state: { item: data } });
+    }
+  };
 
   return (
     <div>
-      <div className="w-[228px] h-[228px] rounded-xl border-2 overflow-hidden mb-3">
+      <div
+        className="w-[228px] h-[228px] rounded-xl border-2 overflow-hidden mb-3"
+        onClick={handleClick}
+      >
         <img src={imageUrl} alt="인근 명소 이미지" className="size-full object-cover" />
       </div>
       <div className="flex justify-between">

--- a/src/components/detail/NearbyPlacesSection.tsx
+++ b/src/components/detail/NearbyPlacesSection.tsx
@@ -38,6 +38,7 @@ export default function NearbyPlacesSection({ path, places }: NearbyPlacesSectio
       </div>
       <div className="flex flex-wrap justify-between">
         {places.map((place, index) => {
+          let data: campingDataResponse | CommonDetails | NearbyRestaurantResponse;
           let imageUrl: string;
           let category: string;
           let name: string;
@@ -46,24 +47,28 @@ export default function NearbyPlacesSection({ path, places }: NearbyPlacesSectio
           const location = place.addr1;
 
           if (isCampingData(place)) {
+            data = place;
             imageUrl = place.firstImageUrl || "https://placehold.co/230x230?text=CAMP+STORY";
             category = place.induty;
             name = place.facltNm;
             channelId = CAMPING_CHANNEL_ID;
             contentId = place.contentId;
           } else if (isEventData(place)) {
+            data = place;
             imageUrl = place.firstimage || "https://placehold.co/230x230?text=CAMP+STORY";
             category = place.contenttypeid === "15" ? "축제" : "행사";
             name = place.title;
             channelId = EVENT_CHANNEL_ID;
             contentId = place.contentid;
           } else if (isRestaurantData(place)) {
+            data = place;
             imageUrl = place.firstimage || "https://placehold.co/230x230?text=CAMP+STORY";
             category = CATEGORY_MAP[place.cat3];
             name = place.title;
             channelId = RESTAURANT_CHANNEL_ID;
             contentId = place.contentid;
           } else {
+            data = place;
             imageUrl = "https://placehold.co/230x230?text=CAMP+STORY";
             category = "기타";
             name = "알 수 없는 명소";
@@ -73,6 +78,7 @@ export default function NearbyPlacesSection({ path, places }: NearbyPlacesSectio
 
           return (
             <NearbyPlaceItem
+              data={data}
               key={index}
               imageUrl={imageUrl}
               category={category}

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -36,6 +36,7 @@ const useEvent = (id: string) => {
             mapX,
             mapY,
             radius,
+            contentTypeId: 15,
           },
         });
 


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#206)

## 💡 변경사항 & 이슈
- 인근 명소 컴포넌트에 클릭 이벤트 추가하여 상세페이지 이동 기능 구현
- 행사페이지 '행사' 카테고리 컨텐츠 클릭 시 발생하는 에러 수정
<br>

## ✍️ 관련 설명
### 1. 인근 명소 컴포넌트 클릭시 페이지 이동
- NearbyPlacesSection에서 NearbyPlaceItem으로 ```data```를 props로 넘겨주었습니다.
- NearbyPlaceItem에서 타입 가드 함수를 통해 ```data``` 타입에 따라 다른 handleClick 이벤트 핸들러를 적용해주었습니다.
```
const handleClick = () => {
    if (isCampingData(data)) {
      navigate(PATH.campingInfo(contentId), { state: { item: data } });
    } else if (isEventData(data)) {
      navigate(PATH.eventInfo(contentId), { state: { event: data } });
    } else if (isRestaurantData(data)) {
      navigate(PATH.restaurantInfo(contentId), { state: { item: data } });
    }
  };

```
### 2. 행사 페이지 에러 해결
- **문제**: 행사 컨텐츠 상세페이지의 인근 명소 섹션에 ‘행사’ 카테고리가 붙은 컨텐츠들이 있는데, 이들은 클릭하면 상세페이지로 이동하지 못하고 에러 발생
![스크린샷 2025-02-06 오후 4 56 11](https://github.com/user-attachments/assets/5a6be0de-ae4b-4352-9f39-989493033356)
![스크린샷 2025-02-06 오후 4 57 43](https://github.com/user-attachments/assets/0eedbf8c-60e7-4912-8bc9-433ccee2c62f)
![스크린샷 2025-02-06 오후 4 57 12](https://github.com/user-attachments/assets/2565494e-e824-4de5-b9bc-c3268bf2afcd)

- **해결**: 컨텐츠타입이 "15" 가 아닌 컨텐츠가 불러와지는 문제라고 판단하여, useEvent hook의 fetchNearbyEvents 함수에 ```contentTypeId:15``` prams 를 추가하여 행사 콘텐츠만 불러오도록 수정했습니다. 이로 인해 의도하지 않은 콘텐츠가 표시되지 않아 문제가 해결되었습니다.
<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
