### PR TITLE
212 creating a custom hook for duplicated code used in more than two components

### DIFF
--- a/src/components/common/WorkerImage.tsx
+++ b/src/components/common/WorkerImage.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react";
+
+interface WorkerImageProps {
+  imageUrl: string;
+  alt?: string;
+  className?: string;
+}
+
+export default function WokerImage({ imageUrl, alt, className }: WorkerImageProps) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const worker = new Worker(new URL("../../worker/imageWorker.ts", import.meta.url), {
+      type: "module",
+    });
+
+    worker.onmessage = (event: MessageEvent<string | { error: string }>) => {
+      if (typeof event.data === "object" && event.data.error) {
+        setError(event.data.error);
+      } else {
+        setDataUrl(event.data as string);
+      }
+    };
+
+    worker.onerror = (err) => {
+      setError(err.message);
+    };
+    worker.postMessage(imageUrl);
+
+    return () => {
+      worker.terminate();
+    };
+  }, [imageUrl]);
+
+  if (error) return <div className="text-gray-scale-200 text-2xl">Error: {error}</div>;
+  if (!dataUrl) return <div className="text-gray-scale-200 text-2xl">Loading image.. {error}</div>;
+
+  return <img src={dataUrl} alt={alt} className={className} />;
+}

--- a/src/components/common/WorkerImage.tsx
+++ b/src/components/common/WorkerImage.tsx
@@ -34,7 +34,7 @@ export default function WokerImage({ imageUrl, alt, className }: WorkerImageProp
   }, [imageUrl]);
 
   if (error) return <div className="text-gray-scale-200 text-2xl">Error: {error}</div>;
-  if (!dataUrl) return <div className="text-gray-scale-200 text-2xl">Loading image.. {error}</div>;
+  if (!dataUrl) return;
 
   return <img src={dataUrl} alt={alt} className={className} />;
 }

--- a/src/components/common/search/SearchCard.tsx
+++ b/src/components/common/search/SearchCard.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent } from "react";
+import WokerImage from "../WorkerImage";
 
 interface SearchCardProps {
   img: string;
@@ -22,8 +23,8 @@ export default function SearchCard({
   return (
     <article className="w-[450px] flex flex-col rounded-xl bg-white overflow-hidden drop-shadow hover:brightness-95">
       <div className="h-[250px] overflow-hidden">
-        <img
-          src={img || "https://placehold.co/450x250?text=CAMP+STORY"}
+        <WokerImage
+          imageUrl={img || "https://placehold.co/450x250?text=CAMP+STORY"}
           alt="thumbanil"
           className="size-full object-cover"
         />

--- a/src/components/shopping/ProductCard.tsx
+++ b/src/components/shopping/ProductCard.tsx
@@ -2,6 +2,7 @@ import { PATH } from "@constants/path";
 import { useNavigate } from "react-router";
 import calculateDiscountRate from "@utils/calculateDiscountRate";
 import { ProductCardProps } from "types/NaverShoppingResponse";
+import WokerImage from "@components/common/WorkerImage";
 
 export default function ProductCard({
   product,
@@ -25,9 +26,9 @@ export default function ProductCard({
         onClick={() => handleNavigateToDetail(productId)}
         className="block w-full h-56 rounded overflow-hidden border"
       >
-        <img
+        <WokerImage
+          imageUrl={image || "https://placehold.co/230x230?text=CAMP+STORY"}
           className="w-full h-full"
-          src={image || "https://placehold.co/230x230?text=CAMP+STORY"}
           alt="Product Image"
         />
       </div>

--- a/src/components/shopping/ProductCard.tsx
+++ b/src/components/shopping/ProductCard.tsx
@@ -8,6 +8,7 @@ export default function ProductCard({
   product,
   bookmarked,
   handleClickBookmark,
+  useNativeImage = false,
 }: ProductCardProps) {
   const { brand, productId, title, mallName, image, hprice, lprice } = product;
 
@@ -26,11 +27,19 @@ export default function ProductCard({
         onClick={() => handleNavigateToDetail(productId)}
         className="block w-full h-56 rounded overflow-hidden border"
       >
-        <WokerImage
-          imageUrl={image || "https://placehold.co/230x230?text=CAMP+STORY"}
-          className="w-full h-full"
-          alt="Product Image"
-        />
+        {useNativeImage ? (
+          <img
+            src={image || "https://placehold.co/230x230?text=CAMP+STORY"}
+            alt="Product Image"
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <WokerImage
+            imageUrl={image || "https://placehold.co/230x230?text=CAMP+STORY"}
+            className="w-full h-full"
+            alt="Product Image"
+          />
+        )}
       </div>
       <div className="mt-3 flex justify-between text-gray-scale-400 text-body2 mb-2">
         {/* 브랜드 및 이름 */}

--- a/src/components/shopping/ProductCardList.tsx
+++ b/src/components/shopping/ProductCardList.tsx
@@ -25,7 +25,10 @@ export default function ProductCardList({
       {products.map((product) => (
         <ProductCard
           key={product.productId}
-          product={product}
+          product={{
+            ...product,
+            image: product.image.replace("https://shopping-phinf.pstatic.net", "/pstatic"),
+          }}
           bookmarked={false}
           handleClickBookmark={() => alert("bookmark")}
         />

--- a/src/pages/CampingSearch.tsx
+++ b/src/pages/CampingSearch.tsx
@@ -199,7 +199,7 @@ export default function CampingSearch() {
                 return (
                   <SearchCard
                     key={item.contentId}
-                    img={item.firstImageUrl}
+                    img={item.firstImageUrl.replace("https://gocamping.or.kr", "/upload")}
                     bookmarked={!!bookmarked}
                     category={item.induty}
                     location={item.addr1}

--- a/src/pages/EventSearch.tsx
+++ b/src/pages/EventSearch.tsx
@@ -255,7 +255,10 @@ export default function EventSearch() {
                 return (
                   <SearchCard
                     key={event.contentid}
-                    img={event.firstimage}
+                    img={event.firstimage.replace(
+                      /^https?:\/\/tong\.visitkorea\.or\.kr/,
+                      "/visitkorea",
+                    )}
                     bookmarked={!!bookmarked}
                     category={category}
                     handleClick={() =>

--- a/src/pages/RestaurantSearch.tsx
+++ b/src/pages/RestaurantSearch.tsx
@@ -14,6 +14,7 @@ import { RESTAURANT_CHANNEL_ID } from "@constants/channelId";
 import useInfiniteScroll from "@hooks/useInfiniteScroll";
 
 interface Item {
+  id: string;
   addr1: string;
   addr2: string;
   cat1: string;
@@ -229,8 +230,11 @@ export default function RestaurantSearch() {
                 const bookmarked = isBookmarked(restaurant.contentid);
                 return (
                   <SearchCard
-                    key={restaurant.contentid}
-                    img={restaurant.firstimage}
+                    key={restaurant.id}
+                    img={restaurant.firstimage.replace(
+                      /^https?:\/\/tong\.visitkorea\.or\.kr/,
+                      "/visitkorea",
+                    )}
                     bookmarked={!!bookmarked}
                     category={CategoryMap[restaurant.cat3] || "카테고리 없음"}
                     handleClick={() =>

--- a/src/pages/ShoppingMain.tsx
+++ b/src/pages/ShoppingMain.tsx
@@ -322,9 +322,13 @@ export default function ShoppingMain() {
           {NewProductData.map((product) => (
             <ProductCard
               key={product.productId}
-              product={product}
+              product={{
+                ...product,
+                image: product.image.replace("https://shopping-phinf.pstatic.net", "/pstatic"),
+              }}
               bookmarked={false}
               handleClickBookmark={() => alert("bookmark")}
+              useNativeImage={true}
             />
           ))}
         </div>
@@ -343,9 +347,13 @@ export default function ShoppingMain() {
           {DiscountProductData.map((product) => (
             <ProductCard
               key={product.productId}
-              product={product}
+              product={{
+                ...product,
+                image: product.image.replace("https://shopping-phinf.pstatic.net", "/pstatic"),
+              }}
               bookmarked={false}
               handleClickBookmark={() => alert("bookmark")}
+              useNativeImage={true}
             />
           ))}
         </div>

--- a/src/types/NaverShoppingResponse.ts
+++ b/src/types/NaverShoppingResponse.ts
@@ -23,4 +23,5 @@ export interface ProductCardProps {
   product: NaverProductResponse;
   bookmarked?: boolean;
   handleClickBookmark?: () => void;
+  useNativeImage?: boolean;
 }

--- a/src/worker/imageWorker.ts
+++ b/src/worker/imageWorker.ts
@@ -1,0 +1,27 @@
+/// <reference lib="webworker" />
+declare const self: DedicatedWorkerGlobalScope;
+
+self.addEventListener("message", async (event: MessageEvent<string>) => {
+  const imageUrl = event.data;
+  try {
+    const response = await fetch(imageUrl);
+    const blob = await response.blob();
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      self.postMessage(reader.result);
+    };
+    reader.onerror = (event: ProgressEvent<FileReader>) => {
+      const error = event.target?.error;
+      self.postMessage({ error: error?.message ? error?.message : "Unknown error" });
+    };
+    console.log("[WebWorker] FileReader로 Blob 읽기 시작");
+    reader.readAsDataURL(blob);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      self.postMessage({ error: error.message });
+    } else {
+      self.postMessage({ error: "Unknown error occurred" });
+    }
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,16 @@
 {
   "files": [],
   "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,24 @@ export default defineConfig({
         secure: false,
         ws: true,
       },
+      "/upload": {
+        target: "https://gocamping.or.kr",
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/upload/, ""),
+      },
+      "/pstatic": {
+        target: "https://shopping-phinf.pstatic.net",
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/pstatic/, ""),
+      },
+      "/visitkorea": {
+        target: "http://tong.visitkorea.or.kr",
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/visitkorea/, ""),
+      },
     },
   },
 });


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#212 )

## 💡 변경사항 & 이슈
- 캠핑,행사,음식,쇼핑 검색페이지에서 웹워커를 사용하여 이미지 렌더링하게 코드를 수정했습니다.
- 쇼핑 메인페이지에서는 **신상품, 최저가 득템** 항목은 웹워커가 삽입된 ProductCard 컴포넌트를 공유하고있어 기본 img 태그로 불러오게 코드를 리팩토링 하였습니다. (위 항목 이미지 로딩이 원본 img태그보다 현저히 **느림**)
- fetch중  이미지홀더에 문자 제거하였습니다.
![image](https://github.com/user-attachments/assets/8111199b-3834-40e1-a07f-852df9208659)

<br>

## ✍️ 관련 설명

<br>

![스크린샷 2025-02-07 175711](https://github.com/user-attachments/assets/88692611-7543-4f94-b9d5-0e86a76cd53b)

![스크린샷 2025-02-07 175947](https://github.com/user-attachments/assets/486a56bd-2ee2-4a5f-abd2-6cb434e5f0ea)


![스크린샷 2025-02-07 175932](https://github.com/user-attachments/assets/c448c0f0-6729-4eb5-9ae9-8c67f5d9f9d4)

## ⭐️ Review point

![image](https://github.com/user-attachments/assets/75f3aef4-c7ba-4bcc-8b19-6188e7cab3da)

그렇다고 합니다..



<br>

## 📷 Demo

<br>
